### PR TITLE
Add widget `Alert::class` agnostic.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
         "php": "^7.4|^8.0",
         "yiisoft/aliases": "^1.1|^2.0",
         "yiisoft/cache": "^1.0",
+        "yiisoft/html": "^2.0",
         "yiisoft/view": "^4.0",
         "yiisoft/widget": "^3.0@dev"
     },

--- a/src/Alert.php
+++ b/src/Alert.php
@@ -31,7 +31,7 @@ final class Alert extends Widget
     private bool $bodyContainer = false;
     private array $bodyContainerAttributes = [];
     private string $bodyContainerClass = '';
-    /** @var non-empty-string */
+    /** @psalm-var non-empty-string */
     private string $bodyTag = 'span';
     private string $class = '';
     private ?string $id = null;
@@ -41,7 +41,7 @@ final class Alert extends Widget
     private bool $headerContainer = false;
     private array $headerContainerAttributes = [];
     private string $headerContainerClass = '';
-    /** @var non-empty-string */
+    /** @psalm-var non-empty-string */
     private string $headerTag = 'span';
     private array $iconAttributes = [];
     private array $iconContainerAttributes = [];

--- a/src/Alert.php
+++ b/src/Alert.php
@@ -57,8 +57,7 @@ final class Alert extends Widget
     }
 
     /**
-     * The message content in the alert component. Alert widget will also be treated as the message content, and will be
-     * rendered before this.
+     * The message content in the alert component.
      *
      * @param string $value
      *
@@ -252,8 +251,7 @@ final class Alert extends Widget
     }
 
     /**
-     * The header content in the alert component. Alert widget will also be treated as the header content, and will be
-     * rendered before this.
+     * The header content in the alert component.
      *
      * @param string $value
      *

--- a/src/Alert.php
+++ b/src/Alert.php
@@ -22,31 +22,22 @@ final class Alert extends Widget
 {
     private array $attributes = [];
     private array $buttonAttributes = [];
-    private string $buttonClass = '';
     private string $buttonLabel = '&times;';
-    private string $buttonOnClick = '';
     private string $body = '';
     private array $bodyAttributes = [];
-    private string $bodyClass = '';
     private bool $bodyContainer = false;
     private array $bodyContainerAttributes = [];
-    private string $bodyContainerClass = '';
     /** @psalm-var non-empty-string */
     private string $bodyTag = 'span';
-    private string $class = '';
     private ?string $id = null;
     private string $header = '';
     private array $headerAttributes = [];
-    private string $headerClass = '';
     private bool $headerContainer = false;
     private array $headerContainerAttributes = [];
-    private string $headerContainerClass = '';
     /** @psalm-var non-empty-string */
     private string $headerTag = 'span';
     private array $iconAttributes = [];
     private array $iconContainerAttributes = [];
-    private string $iconContainerClass = '';
-    private string $iconClass = '';
     private string $iconText = '';
     private string $layoutHeader = '';
     private string $layoutBody = '{body}{button}';
@@ -107,7 +98,7 @@ final class Alert extends Widget
     public function bodyClass(string $value): self
     {
         $new = clone $this;
-        $new->bodyClass = $value;
+        Html::addCssClass($new->bodyAttributes, $value);
         return $new;
     }
 
@@ -151,7 +142,7 @@ final class Alert extends Widget
     public function bodyContainerClass(string $value): self
     {
         $new = clone $this;
-        $new->bodyContainerClass = $value;
+        Html::addCssClass($new->bodyContainerAttributes, $value);
         return $new;
     }
 
@@ -208,7 +199,7 @@ final class Alert extends Widget
     public function buttonClass(string $value): self
     {
         $new = clone $this;
-        $new->buttonClass = $value;
+        Html::addCssClass($new->buttonAttributes, $value);
         return $new;
     }
 
@@ -233,10 +224,10 @@ final class Alert extends Widget
      *
      * @return static
      */
-    public function buttonOnClick(string $value = ''): self
+    public function buttonOnClick(string $value): self
     {
         $new = clone $this;
-        $new->buttonOnClick = $value;
+        $new->buttonAttributes['onclick'] = $value;
         return $new;
     }
 
@@ -250,7 +241,7 @@ final class Alert extends Widget
     public function class(string $value): self
     {
         $new = clone $this;
-        $new->class = $value;
+        Html::addCssClass($new->attributes, $value);
         return $new;
     }
 
@@ -302,7 +293,7 @@ final class Alert extends Widget
     public function headerClass(string $value): self
     {
         $new = clone $this;
-        $new->headerClass = $value;
+        Html::addCssClass($new->headerAttributes, $value);
         return $new;
     }
 
@@ -330,7 +321,7 @@ final class Alert extends Widget
     public function headerContainerClass(string $value): self
     {
         $new = clone $this;
-        $new->headerContainerClass = $value;
+        Html::addCssClass($new->headerContainerAttributes, $value);
         return $new;
     }
 
@@ -396,7 +387,7 @@ final class Alert extends Widget
     public function iconClass(string $value): self
     {
         $new = clone $this;
-        $new->iconClass = $value;
+        Html::addCssClass($new->iconAttributes, $value);
         return $new;
     }
 
@@ -428,7 +419,7 @@ final class Alert extends Widget
     public function iconContainerClass(string $value): self
     {
         $new = clone $this;
-        $new->iconContainerClass = $value;
+        Html::addCssClass($new->iconContainerAttributes, $value);
         return $new;
     }
 
@@ -485,7 +476,6 @@ final class Alert extends Widget
     private function renderAlert(): string
     {
         $new = clone $this;
-        $new->attributes['role'] = 'alert';
         $new->attributes['id'] ??= $new->id ?? Html::generateId('alert-');
 
         if (!isset($new->parts['{button}'])) {
@@ -506,12 +496,9 @@ final class Alert extends Widget
 
         $contentAlert = $new->renderPanelHeader($new) . PHP_EOL . $new->renderPanelBody($new);
 
-        if ($new->class !== '') {
-            Html::addCssClass($new->attributes, $new->class);
-        }
-
         return $new->body !== ''
             ? Div::tag()
+                ->attribute('role', 'alert')
                 ->attributes($new->attributes)
                 ->content(PHP_EOL . trim($contentAlert) . PHP_EOL)
                 ->encode(false)
@@ -524,16 +511,6 @@ final class Alert extends Widget
      */
     private function renderCloseButton(self $new): void
     {
-        $new->parts['{button}'] = '';
-
-        if ($new->buttonOnClick !== '') {
-            $new->buttonAttributes['onclick'] = $new->buttonOnClick;
-        }
-
-        if ($new->buttonClass !== '') {
-            Html::addCssClass($new->buttonAttributes, $new->buttonClass);
-        }
-
         $new->parts['{button}'] = PHP_EOL .
             Button::tag()
                 ->attributes($new->buttonAttributes)
@@ -548,14 +525,6 @@ final class Alert extends Widget
      */
     private function renderIcon(self $new): void
     {
-        if ($new->iconClass !== '') {
-            Html::addCssClass($new->iconAttributes, $new->iconClass);
-        }
-
-        if ($new->iconContainerClass !== '') {
-            Html::addCssClass($new->iconContainerAttributes, $new->iconContainerClass);
-        }
-
         $icon = CustomTag::name('i')->attributes($new->iconAttributes)->content($new->iconText)->render();
 
         $new->parts['{icon}'] = PHP_EOL .
@@ -571,10 +540,6 @@ final class Alert extends Widget
      */
     private function renderBody(self $new): void
     {
-        if ($new->bodyClass !== '') {
-            Html::addCssClass($new->bodyAttributes, $new->bodyClass);
-        }
-
         $new->parts['{body}'] = CustomTag::name($new->bodyTag)
             ->attributes($new->bodyAttributes)
             ->content($new->body)
@@ -587,10 +552,6 @@ final class Alert extends Widget
      */
     private function renderHeader(self $new): void
     {
-        if ($new->headerClass !== '') {
-            Html::addCssClass($new->headerAttributes, $new->headerClass);
-        }
-
         $new->parts['{header}'] = CustomTag::name($new->headerTag)
             ->attributes($new->headerAttributes)
             ->content($new->header)
@@ -604,10 +565,6 @@ final class Alert extends Widget
     private function renderPanelHeader(self $new): string
     {
         $headerHtml = trim(strtr($new->layoutHeader, $new->parts));
-
-        if ($new->headerContainerClass !== '') {
-            Html::addCssClass($new->headerContainerAttributes, $new->headerContainerClass);
-        }
 
         if ($new->headerContainer && $headerHtml !== '') {
             $headerHtml = Div::tag()
@@ -626,10 +583,6 @@ final class Alert extends Widget
     private function renderPanelBody(self $new): string
     {
         $bodyHtml = trim(strtr($new->layoutBody, $new->parts));
-
-        if ($new->bodyContainerClass !== '') {
-            Html::addCssClass($new->bodyContainerAttributes, $new->bodyContainerClass);
-        }
 
         if ($new->bodyContainer) {
             $bodyHtml = Div::tag()

--- a/src/Alert.php
+++ b/src/Alert.php
@@ -1,0 +1,643 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Yii\Widgets;
+
+use InvalidArgumentException;
+use Yiisoft\Html\Html;
+use Yiisoft\Html\Tag\Button;
+use Yiisoft\Html\Tag\CustomTag;
+use Yiisoft\Html\Tag\Div;
+use Yiisoft\Widget\Widget;
+
+/**
+ * Alert renders an alert component.
+ *
+ * @link https://getbootstrap.com/docs/5.0/components/alerts/
+ * @link https://bulma.io/documentation/elements/notification/
+ * @link https://tailwindui.com/components/application-ui/feedback/alerts
+ */
+final class Alert extends Widget
+{
+    private array $attributes = [];
+    private array $buttonAttributes = [];
+    private string $buttonClass = '';
+    private string $buttonLabel = '&times;';
+    private string $buttonOnClick = '';
+    private string $body = '';
+    private array $bodyAttributes = [];
+    private string $bodyClass = '';
+    private bool $bodyContainer = false;
+    private array $bodyContainerAttributes = [];
+    private string $bodyContainerClass = '';
+    /** @var non-empty-string */
+    private string $bodyTag = 'span';
+    private string $class = '';
+    private ?string $id = null;
+    private string $header = '';
+    private array $headerAttributes = [];
+    private string $headerClass = '';
+    private bool $headerContainer = false;
+    private array $headerContainerAttributes = [];
+    private string $headerContainerClass = '';
+    /** @var non-empty-string */
+    private string $headerTag = 'span';
+    private array $iconAttributes = [];
+    private array $iconContainerAttributes = [];
+    private string $iconContainerClass = '';
+    private string $iconClass = '';
+    private string $iconText = '';
+    private string $layoutHeader = '';
+    private string $layoutBody = '{body}{button}';
+    private array $parts = [];
+
+    /**
+     * The HTML attributes for widget. The following special options are recognized.
+     *
+     * @param array $value
+     *
+     * @return static
+     */
+    public function attributes(array $value): self
+    {
+        $new = clone $this;
+        $new->attributes = $value;
+        return $new;
+    }
+
+    /**
+     * The message content in the alert component. Alert widget will also be treated as the message content, and will be
+     * rendered before this.
+     *
+     * @param string $value
+     *
+     * @return static
+     */
+    public function body(string $value): self
+    {
+        $new = clone $this;
+        $new->body = $value;
+        return $new;
+    }
+
+    /**
+     * The attributes for rendering message content in the alert component.
+     *
+     * @param array $value
+     *
+     * @return static
+     *
+     * {@see Html::renderTagAttributes()} for details on how attributes are being rendered.
+     */
+    public function bodyAttributes(array $value): self
+    {
+        $new = clone $this;
+        $new->bodyAttributes = $value;
+        return $new;
+    }
+
+    /**
+     * The CSS class for the alert panel body.
+     *
+     * @param string $value
+     *
+     * @return static
+     */
+    public function bodyClass(string $value): self
+    {
+        $new = clone $this;
+        $new->bodyClass = $value;
+        return $new;
+    }
+
+    /**
+     * Allows you to add a div tag to the alert panel body.
+     *
+     * @param bool $value
+     *
+     * @return static
+     */
+    public function bodyContainer(bool $value = true): self
+    {
+        $new = clone $this;
+        $new->bodyContainer = $value;
+        return $new;
+    }
+
+    /**
+     * The attributes for rendering the panel alert body.
+     *
+     * @param array $value
+     *
+     * @return static
+     *
+     * {@see Html::renderTagAttributes()} for details on how attributes are being rendered.
+     */
+    public function bodyContainerAttributes(array $value): self
+    {
+        $new = clone $this;
+        $new->bodyContainerAttributes = $value;
+        return $new;
+    }
+
+    /**
+     * The CSS class for the alert panel body.
+     *
+     * @param string $value
+     *
+     * @return static
+     */
+    public function bodyContainerClass(string $value): self
+    {
+        $new = clone $this;
+        $new->bodyContainerClass = $value;
+        return $new;
+    }
+
+    /**
+     * Set tag name for the alert panel body.
+     *
+     * @param string $value
+     *
+     * @return static
+     * @throws InvalidArgumentException
+     *
+     */
+    public function bodyTag(string $value): self
+    {
+        if (empty($value)) {
+            throw new InvalidArgumentException('Body tag must be a string and cannot be empty.');
+        }
+
+        $new = clone $this;
+        $new->bodyTag = $value;
+        return $new;
+    }
+
+    /**
+     * The attributes for rendering the close button tag.
+     *
+     * The close button is displayed in the header of the modal window. Clicking on the button will hide the modal
+     * window.
+     *
+     * If {@see closeButtonEnabled} is false, no close button will be rendered.
+     *
+     * The rest of the options will be rendered as the HTML attributes of the button tag.
+     *
+     * @param array $value
+     *
+     * @return static
+     *
+     * {@see Html::renderTagAttributes()} for details on how attributes are being rendered.
+     */
+    public function buttonAttributes(array $value): self
+    {
+        $new = clone $this;
+        $new->buttonAttributes = $value;
+        return $new;
+    }
+
+    /**
+     * The CSS class for the close button.
+     *
+     * @param string $value
+     *
+     * @return static
+     */
+    public function buttonClass(string $value): self
+    {
+        $new = clone $this;
+        $new->buttonClass = $value;
+        return $new;
+    }
+
+    /**
+     * The label for the close button.
+     *
+     * @param string $value
+     *
+     * @return static
+     */
+    public function buttonLabel(string $value = ''): self
+    {
+        $new = clone $this;
+        $new->buttonLabel = $value;
+        return $new;
+    }
+
+    /**
+     * The onclick JavaScript for the close button.
+     *
+     * @param string $value
+     *
+     * @return static
+     */
+    public function buttonOnClick(string $value = ''): self
+    {
+        $new = clone $this;
+        $new->buttonOnClick = $value;
+        return $new;
+    }
+
+    /**
+     * Set attribute class for widget.
+     *
+     * @param string $value
+     *
+     * @return static
+     */
+    public function class(string $value): self
+    {
+        $new = clone $this;
+        $new->class = $value;
+        return $new;
+    }
+
+    public function id(?string $value): self
+    {
+        $new = clone $this;
+        $new->id = $value;
+        return $new;
+    }
+    /**
+     * The header content in the alert component. Alert widget will also be treated as the header content, and will be
+     * rendered before this.
+     *
+     * @param string $value
+     *
+     * @return static
+     */
+    public function header(string $value): self
+    {
+        $new = clone $this;
+        $new->header = $value;
+        return $new;
+    }
+
+    /**
+     * The attributes for rendering the header content in the alert component.
+     *
+     * @param array $value
+     *
+     * @return static
+     *
+     * {@see Html::renderTagAttributes()} for details on how attributes are being rendered.
+     */
+    public function headerAttributes(array $value): self
+    {
+        $new = clone $this;
+        $new->headerAttributes = $value;
+        return $new;
+    }
+
+    /**
+     * The CSS class for the alert panel header.
+     *
+     * @param string $value
+     *
+     * @return static
+     */
+    public function headerClass(string $value): self
+    {
+        $new = clone $this;
+        $new->headerClass = $value;
+        return $new;
+    }
+
+    /**
+     * Allows you to add a div tag to the alert panel header.
+     *
+     * @param bool $value
+     *
+     * @return static
+     */
+    public function headerContainer(bool $value = true): self
+    {
+        $new = clone $this;
+        $new->headerContainer = $value;
+        return $new;
+    }
+
+    /**
+     * The CSS class for the alert panel header.
+     *
+     * @param string $value
+     *
+     * @return static
+     */
+    public function headerContainerClass(string $value): self
+    {
+        $new = clone $this;
+        $new->headerContainerClass = $value;
+        return $new;
+    }
+
+    /**
+     * The attributes for rendering the panel alert header.
+     *
+     * @param array $value
+     *
+     * @return static
+     *
+     * {@see Html::renderTagAttributes()} for details on how attributes are being rendered.
+     */
+    public function headerContainerAttributes(array $value): self
+    {
+        $new = clone $this;
+        $new->headerContainerAttributes = $value;
+        return $new;
+    }
+
+    /**
+     * Set tag name for the alert panel header.
+     *
+     * @param string $value
+     *
+     * @return static
+     * @throws InvalidArgumentException
+     *
+     */
+    public function headerTag(string $value): self
+    {
+        if (empty($value)) {
+            throw new InvalidArgumentException('Header tag must be a string and cannot be empty.');
+        }
+
+        $new = clone $this;
+        $new->headerTag = $value;
+        return $new;
+    }
+
+    /**
+     * The attributes for rendering the `<i>` tag for icons alerts.
+     *
+     * @param array $value
+     *
+     * @return static
+     *
+     * {@see Html::renderTagAttributes()} for details on how attributes are being rendered.
+     */
+    public function iconAttributes(array $value): self
+    {
+        $new = clone $this;
+        $new->iconAttributes = $value;
+        return $new;
+    }
+
+    /**
+     * Set icon css class in the alert component.
+     *
+     * @param string $value
+     *
+     * @return static
+     */
+    public function iconClass(string $value): self
+    {
+        $new = clone $this;
+        $new->iconClass = $value;
+        return $new;
+    }
+
+    /**
+     * The attributes for rendering the container `<i>` tag.
+     *
+     * The rest of the options will be rendered as the HTML attributes of the `<i>` tag.
+     *
+     * @param array $value
+     *
+     * @return static
+     *
+     * {@see Html::renderTagAttributes()} for details on how attributes are being rendered.
+     */
+    public function iconContainerAttributes(array $value): self
+    {
+        $new = clone $this;
+        $new->iconContainerAttributes = $value;
+        return $new;
+    }
+
+    /**
+     * The CSS class for the container `<i>` tag.
+     *
+     * @param string $value
+     *
+     * @return static
+     */
+    public function iconContainerClass(string $value): self
+    {
+        $new = clone $this;
+        $new->iconContainerClass = $value;
+        return $new;
+    }
+
+    /**
+     * Set icon text in the alert component.
+     *
+     * @param string $value
+     *
+     * @return static
+     */
+    public function iconText(string $value): self
+    {
+        $new = clone $this;
+        $new->iconText = $value;
+        return $new;
+    }
+
+    /**
+     * Set layout the alert panel body.
+     *
+     * @param string $value
+     *
+     * @return static
+     */
+    public function layoutBody(string $value): self
+    {
+        $new = clone $this;
+        $new->layoutBody = $value;
+        return $new;
+    }
+
+    /**
+     * Set layout the alert panel header.
+     *
+     * @param string $value
+     *
+     * @return static
+     */
+    public function layoutHeader(string $value): self
+    {
+        $new = clone $this;
+        $new->layoutHeader = $value;
+        return $new;
+    }
+
+    protected function run(): string
+    {
+        $new = clone $this;
+        return $new->renderAlert($new);
+    }
+
+    /**
+     * Render Alert.
+     */
+    private function renderAlert(self $new): string
+    {
+        $new->attributes['role'] = 'alert';
+        $new->attributes['id'] ??= $new->id ?? Html::generateId('alert-');
+
+        if (!isset($new->parts['{button}'])) {
+            $new->renderCloseButton($new);
+        }
+
+        if (!isset($new->parts['{icon}'])) {
+            $new->renderIcon($new);
+        }
+
+        if (!isset($new->parts['{body}'])) {
+            $new->renderBody($new);
+        }
+
+        if (!isset($new->parts['{header}'])) {
+            $new->renderHeader($new);
+        }
+
+        $contentAlert = $new->renderPanelHeader($new) . PHP_EOL . $new->renderPanelBody($new);
+
+        if ($new->class !== '') {
+            Html::addCssClass($new->attributes, $new->class);
+        }
+
+        return $new->body !== ''
+            ? Div::tag()
+                ->attributes($new->attributes)
+                ->content(PHP_EOL . trim($contentAlert) . PHP_EOL)
+                ->encode(false)
+                ->render()
+            : '';
+    }
+
+    /**
+     * Renders close button.
+     */
+    private function renderCloseButton(self $new): void
+    {
+        $new->parts['{button}'] = '';
+
+        if ($new->buttonOnClick !== '') {
+            $new->buttonAttributes['onclick'] = $new->buttonOnClick;
+        }
+
+        if ($new->buttonClass !== '') {
+            Html::addCssClass($new->buttonAttributes, $new->buttonClass);
+        }
+
+        $new->parts['{button}'] = PHP_EOL .
+            Button::tag()
+                ->attributes($new->buttonAttributes)
+                ->content($new->buttonLabel)
+                ->encode(false)
+                ->type('button')
+                ->render();
+    }
+
+    /**
+     * Render icon.
+     */
+    private function renderIcon(self $new): void
+    {
+        if ($new->iconClass !== '') {
+            Html::addCssClass($new->iconAttributes, $new->iconClass);
+        }
+
+        if ($new->iconContainerClass !== '') {
+            Html::addCssClass($new->iconContainerAttributes, $new->iconContainerClass);
+        }
+
+        $icon = CustomTag::name('i')->attributes($new->iconAttributes)->content($new->iconText)->render();
+
+        $new->parts['{icon}'] = PHP_EOL .
+            Div::tag()
+                ->attributes($new->iconContainerAttributes)
+                ->content($icon)
+                ->encode(false)
+                ->render() . PHP_EOL;
+    }
+
+    /**
+     * Render the alert message.
+     */
+    private function renderBody(self $new): void
+    {
+        if ($new->bodyClass !== '') {
+            Html::addCssClass($new->bodyAttributes, $new->bodyClass);
+        }
+
+        $new->parts['{body}'] = CustomTag::name($new->bodyTag)
+            ->attributes($new->bodyAttributes)
+            ->content($new->body)
+            ->encode(false)
+            ->render();
+    }
+
+    /**
+     * Render the alert message header.
+     */
+    private function renderHeader(self $new): void
+    {
+        if ($new->headerClass !== '') {
+            Html::addCssClass($new->headerAttributes, $new->headerClass);
+        }
+
+        $new->parts['{header}'] = CustomTag::name($new->headerTag)
+            ->attributes($new->headerAttributes)
+            ->content($new->header)
+            ->encode(false)
+            ->render();
+    }
+
+    /**
+     * Render the alert panel header.
+     */
+    private function renderPanelHeader(self $new): string
+    {
+        $headerHtml = trim(strtr($new->layoutHeader, $new->parts));
+
+        if ($new->headerContainerClass !== '') {
+            Html::addCssClass($new->headerContainerAttributes, $new->headerContainerClass);
+        }
+
+        if ($new->headerContainer && $headerHtml !== '') {
+            $headerHtml = Div::tag()
+                ->attributes($new->headerContainerAttributes)
+                ->content(PHP_EOL . $headerHtml . PHP_EOL)
+                ->encode(false)
+                ->render();
+        }
+
+        return $headerHtml;
+    }
+
+    /**
+     * Render the alert panel body.
+     */
+    private function renderPanelBody(self $new): string
+    {
+        $bodyHtml = trim(strtr($new->layoutBody, $new->parts));
+
+        if ($new->bodyContainerClass !== '') {
+            Html::addCssClass($new->bodyContainerAttributes, $new->bodyContainerClass);
+        }
+
+        if ($new->bodyContainer) {
+            $bodyHtml = Div::tag()
+                ->attributes($new->bodyContainerAttributes)
+                ->content(PHP_EOL . $bodyHtml . PHP_EOL)
+                ->encode(false)
+                ->render();
+        }
+
+        return $bodyHtml;
+    }
+}

--- a/src/Alert.php
+++ b/src/Alert.php
@@ -26,7 +26,7 @@ final class Alert extends Widget
     private string $body = '';
     private array $bodyAttributes = [];
     /** @psalm-var non-empty-string */
-    private string|null $bodyContainer = 'span';
+    private ?string $bodyContainer = 'span';
     private bool $bodyContainerPanel = false;
     private array $bodyContainerAttributes = [];
     private string $header = '';

--- a/src/Alert.php
+++ b/src/Alert.php
@@ -25,10 +25,10 @@ final class Alert extends Widget
     private string $buttonLabel = '&times;';
     private string $body = '';
     private array $bodyAttributes = [];
-    private bool $bodyContainer = false;
-    private array $bodyContainerAttributes = [];
     /** @psalm-var non-empty-string */
-    private string $bodyTag = 'span';
+    private string|null $bodyContainer = 'span';
+    private bool $bodyContainerPanel = false;
+    private array $bodyContainerAttributes = [];
     private string $header = '';
     private array $headerAttributes = [];
     private bool $headerContainer = false;
@@ -43,9 +43,9 @@ final class Alert extends Widget
     private array $parts = [];
 
     /**
-     * The HTML attributes for widget. The following special options are recognized.
+     * The HTML attributes for the main widget tag.
      *
-     * @param array $value
+     * @param array $value Array of attribute name => attribute value pairs.
      *
      * @return static
      */
@@ -57,9 +57,9 @@ final class Alert extends Widget
     }
 
     /**
-     * The message content in the alert component.
+     * The message body.
      *
-     * @param string $value
+     * @param string $value The message body.
      *
      * @return static
      */
@@ -71,9 +71,9 @@ final class Alert extends Widget
     }
 
     /**
-     * The attributes for rendering message content in the alert component.
+     * HTML attributes for the message body tag.
      *
-     * @param array $value
+     * @param array $value Array of attribute name => attribute value pairs.
      *
      * @return static
      *
@@ -87,9 +87,9 @@ final class Alert extends Widget
     }
 
     /**
-     * The CSS class for the alert panel body.
+     * CSS class for the message body tag.
      *
-     * @param string $value
+     * @param string $value CSS class name.
      *
      * @return static
      */
@@ -101,21 +101,25 @@ final class Alert extends Widget
     }
 
     /**
-     * Allows you to add a div tag to the alert panel body.
+     * Allows you to add an extra wrapper for the message body.
      *
-     * @param bool $value
+     * @param string|null $tag
      *
      * @return static
      */
-    public function bodyContainer(bool $value = true): self
+    public function bodyContainer(?string $tag = null): self
     {
+        if ($tag === '') {
+            throw new InvalidArgumentException('Body tag must be a string and cannot be empty.');
+        }
+
         $new = clone $this;
-        $new->bodyContainer = $value;
+        $new->bodyContainer = $tag;
         return $new;
     }
 
     /**
-     * The attributes for rendering the panel alert body.
+     * The attributes for rendering extra message wrapper.
      *
      * @param array $value
      *
@@ -131,7 +135,7 @@ final class Alert extends Widget
     }
 
     /**
-     * The CSS class for the alert panel body.
+     * The CSS class for extra message wrapper.
      *
      * @param string $value
      *
@@ -145,32 +149,25 @@ final class Alert extends Widget
     }
 
     /**
-     * Set tag name for the alert panel body.
+     * Allows you to add an extra wrapper for the panel body.
      *
-     * @param string $value
-     *
-     * @throws InvalidArgumentException
+     * @param bool $value
      *
      * @return static
      */
-    public function bodyTag(string $value): self
+    public function bodyContainerPanel(bool $value): self
     {
-        if (empty($value)) {
-            throw new InvalidArgumentException('Body tag must be a string and cannot be empty.');
-        }
-
         $new = clone $this;
-        $new->bodyTag = $value;
+        $new->bodyContainerPanel = $value;
         return $new;
     }
 
     /**
-     * The attributes for rendering the close button tag.
+     * The attributes for rendering the button tag.
      *
-     * The close button is displayed in the header of the modal window. Clicking on the button will hide the modal
-     * window.
+     * The button is displayed in the header of the modal window. Clicking on the button will hide the modal.
      *
-     * If {@see closeButtonEnabled} is false, no close button will be rendered.
+     * If {@see buttonEnabled} is `false`, no button will be rendered.
      *
      * The rest of the options will be rendered as the HTML attributes of the button tag.
      *
@@ -188,7 +185,7 @@ final class Alert extends Widget
     }
 
     /**
-     * The CSS class for the close button.
+     * The CSS class for the button.
      *
      * @param string $value
      *
@@ -202,7 +199,7 @@ final class Alert extends Widget
     }
 
     /**
-     * The label for the close button.
+     * The label for the button.
      *
      * @param string $value
      *
@@ -216,7 +213,7 @@ final class Alert extends Widget
     }
 
     /**
-     * The onclick JavaScript for the close button.
+     * The onclick JavaScript for the button.
      *
      * @param string $value
      *
@@ -230,7 +227,7 @@ final class Alert extends Widget
     }
 
     /**
-     * Set attribute class for widget.
+     * Set attribute class for main widget tag.
      *
      * @param string $value
      *
@@ -251,7 +248,7 @@ final class Alert extends Widget
     }
 
     /**
-     * The header content in the alert component.
+     * The header content.
      *
      * @param string $value
      *
@@ -265,7 +262,7 @@ final class Alert extends Widget
     }
 
     /**
-     * The attributes for rendering the header content in the alert component.
+     * The attributes for rendering the header content.
      *
      * @param array $value
      *
@@ -281,7 +278,7 @@ final class Alert extends Widget
     }
 
     /**
-     * The CSS class for the alert panel header.
+     * The CSS class for the header.
      *
      * @param string $value
      *
@@ -295,7 +292,7 @@ final class Alert extends Widget
     }
 
     /**
-     * Allows you to add a div tag to the alert panel header.
+     * Allows you to add a div tag to the header extra wrapper.
      *
      * @param bool $value
      *
@@ -309,7 +306,7 @@ final class Alert extends Widget
     }
 
     /**
-     * The CSS class for the alert panel header.
+     * The CSS class for the header extra wrapper.
      *
      * @param string $value
      *
@@ -323,7 +320,7 @@ final class Alert extends Widget
     }
 
     /**
-     * The attributes for rendering the panel alert header.
+     * The attributes for rendering the header.
      *
      * @param array $value
      *
@@ -339,7 +336,7 @@ final class Alert extends Widget
     }
 
     /**
-     * Set tag name for the alert panel header.
+     * Set tag name for the header.
      *
      * @param string $value
      *
@@ -359,7 +356,7 @@ final class Alert extends Widget
     }
 
     /**
-     * The attributes for rendering the `<i>` tag for icons alerts.
+     * The attributes for rendering the `<i>` tag for the icon.
      *
      * @param array $value
      *
@@ -375,7 +372,7 @@ final class Alert extends Widget
     }
 
     /**
-     * Set icon css class in the alert component.
+     * Set icon CSS class.
      *
      * @param string $value
      *
@@ -389,9 +386,9 @@ final class Alert extends Widget
     }
 
     /**
-     * The attributes for rendering the container `<i>` tag.
+     * The attributes for rendering icon container.
      *
-     * The rest of the options will be rendered as the HTML attributes of the `<i>` tag.
+     * The rest of the options will be rendered as the HTML attributes of the icon container.
      *
      * @param array $value
      *
@@ -407,7 +404,7 @@ final class Alert extends Widget
     }
 
     /**
-     * The CSS class for the container `<i>` tag.
+     * The CSS class for the icon container.
      *
      * @param string $value
      *
@@ -421,7 +418,7 @@ final class Alert extends Widget
     }
 
     /**
-     * Set icon text in the alert component.
+     * Set icon text.
      *
      * @param string $value
      *
@@ -435,7 +432,7 @@ final class Alert extends Widget
     }
 
     /**
-     * Set layout the alert panel body.
+     * Set layout body.
      *
      * @param string $value
      *
@@ -449,7 +446,7 @@ final class Alert extends Widget
     }
 
     /**
-     * Set layout the alert panel header.
+     * Set layout header.
      *
      * @param string $value
      *
@@ -472,7 +469,7 @@ final class Alert extends Widget
         }
 
         if (!isset($new->parts['{button}'])) {
-            $new->renderCloseButton($new);
+            $new->renderButton($new);
         }
 
         if (!isset($new->parts['{icon}'])) {
@@ -487,7 +484,7 @@ final class Alert extends Widget
             $new->renderHeader($new);
         }
 
-        $contentAlert = $new->renderPanelHeader($new) . PHP_EOL . $new->renderPanelBody($new);
+        $contentAlert = $new->renderHeaderContainer($new) . PHP_EOL . $new->renderPanelBody($new);
 
         return $new->body !== ''
             ? $div
@@ -502,7 +499,7 @@ final class Alert extends Widget
     /**
      * Renders close button.
      */
-    private function renderCloseButton(self $new): void
+    private function renderButton(self $new): void
     {
         $new->parts['{button}'] = PHP_EOL .
             Button::tag()
@@ -529,19 +526,23 @@ final class Alert extends Widget
     }
 
     /**
-     * Render the alert message.
+     * Render the alert message body.
      */
     private function renderBody(self $new): void
     {
-        $new->parts['{body}'] = CustomTag::name($new->bodyTag)
-            ->attributes($new->bodyAttributes)
-            ->content($new->body)
-            ->encode(false)
-            ->render();
+        if ($new->bodyContainer !== null) {
+            $new->parts['{body}'] = CustomTag::name($new->bodyContainer)
+                ->attributes($new->bodyAttributes)
+                ->content($new->body)
+                ->encode(false)
+                ->render();
+        } else {
+            $new->parts['{body}'] = $new->body;
+        }
     }
 
     /**
-     * Render the alert message header.
+     * Render the header.
      */
     private function renderHeader(self $new): void
     {
@@ -553,9 +554,9 @@ final class Alert extends Widget
     }
 
     /**
-     * Render the alert panel header.
+     * Render the header container.
      */
-    private function renderPanelHeader(self $new): string
+    private function renderHeaderContainer(self $new): string
     {
         $headerHtml = trim(strtr($new->layoutHeader, $new->parts));
 
@@ -571,13 +572,13 @@ final class Alert extends Widget
     }
 
     /**
-     * Render the alert panel body.
+     * Render the panel body.
      */
     private function renderPanelBody(self $new): string
     {
         $bodyHtml = trim(strtr($new->layoutBody, $new->parts));
 
-        if ($new->bodyContainer) {
+        if ($new->bodyContainerPanel) {
             $bodyHtml = Div::tag()
                 ->attributes($new->bodyContainerAttributes)
                 ->content(PHP_EOL . $bodyHtml . PHP_EOL)

--- a/src/Alert.php
+++ b/src/Alert.php
@@ -479,7 +479,7 @@ final class Alert extends Widget
         $div = Div::tag();
 
         if (!array_key_exists('id', $this->attributes)) {
-            $div->id(Html::generateId('alert-'));
+            $div = $div->id(Html::generateId('alert-'));
         }
 
         if (!isset($new->parts['{button}'])) {

--- a/src/Alert.php
+++ b/src/Alert.php
@@ -466,16 +466,7 @@ final class Alert extends Widget
 
     protected function run(): string
     {
-        return $this->renderAlert();
-    }
-
-    /**
-     * Render Alert.
-     */
-    private function renderAlert(): string
-    {
         $new = clone $this;
-
         $div = Div::tag();
 
         if (!array_key_exists('id', $this->attributes)) {

--- a/src/Alert.php
+++ b/src/Alert.php
@@ -26,8 +26,8 @@ final class Alert extends Widget
     private string $body = '';
     private array $bodyAttributes = [];
     /** @psalm-var non-empty-string */
-    private ?string $bodyContainer = 'span';
-    private bool $bodyContainerPanel = false;
+    private ?string $bodyTag = 'span';
+    private bool $bodyContainer = false;
     private array $bodyContainerAttributes = [];
     private string $header = '';
     private array $headerAttributes = [];
@@ -107,14 +107,14 @@ final class Alert extends Widget
      *
      * @return static
      */
-    public function bodyContainer(?string $tag = null): self
+    public function bodyTag(?string $tag = null): self
     {
         if ($tag === '') {
             throw new InvalidArgumentException('Body tag must be a string and cannot be empty.');
         }
 
         $new = clone $this;
-        $new->bodyContainer = $tag;
+        $new->bodyTag = $tag;
         return $new;
     }
 
@@ -155,10 +155,10 @@ final class Alert extends Widget
      *
      * @return static
      */
-    public function bodyContainerPanel(bool $value): self
+    public function bodyContainer(bool $value): self
     {
         $new = clone $this;
-        $new->bodyContainerPanel = $value;
+        $new->bodyContainer = $value;
         return $new;
     }
 
@@ -484,7 +484,7 @@ final class Alert extends Widget
             $new->renderHeader($new);
         }
 
-        $contentAlert = $new->renderHeaderContainer($new) . PHP_EOL . $new->renderPanelBody($new);
+        $contentAlert = $new->renderHeaderContainer($new) . PHP_EOL . $new->renderBodyContainer($new);
 
         return $new->body !== ''
             ? $div
@@ -530,8 +530,8 @@ final class Alert extends Widget
      */
     private function renderBody(self $new): void
     {
-        if ($new->bodyContainer !== null) {
-            $new->parts['{body}'] = CustomTag::name($new->bodyContainer)
+        if ($new->bodyTag !== null) {
+            $new->parts['{body}'] = CustomTag::name($new->bodyTag)
                 ->attributes($new->bodyAttributes)
                 ->content($new->body)
                 ->encode(false)
@@ -574,11 +574,11 @@ final class Alert extends Widget
     /**
      * Render the panel body.
      */
-    private function renderPanelBody(self $new): string
+    private function renderBodyContainer(self $new): string
     {
         $bodyHtml = trim(strtr($new->layoutBody, $new->parts));
 
-        if ($new->bodyContainerPanel) {
+        if ($new->bodyContainer) {
             $bodyHtml = Div::tag()
                 ->attributes($new->bodyContainerAttributes)
                 ->content(PHP_EOL . $bodyHtml . PHP_EOL)

--- a/src/Alert.php
+++ b/src/Alert.php
@@ -475,15 +475,15 @@ final class Alert extends Widget
 
     protected function run(): string
     {
-        $new = clone $this;
-        return $new->renderAlert($new);
+        return $this->renderAlert();
     }
 
     /**
      * Render Alert.
      */
-    private function renderAlert(self $new): string
+    private function renderAlert(): string
     {
+        $new = clone $this;
         $new->attributes['role'] = 'alert';
         $new->attributes['id'] ??= $new->id ?? Html::generateId('alert-');
 

--- a/src/Alert.php
+++ b/src/Alert.php
@@ -29,7 +29,6 @@ final class Alert extends Widget
     private array $bodyContainerAttributes = [];
     /** @psalm-var non-empty-string */
     private string $bodyTag = 'span';
-    private ?string $id = null;
     private string $header = '';
     private array $headerAttributes = [];
     private bool $headerContainer = false;
@@ -248,7 +247,7 @@ final class Alert extends Widget
     public function id(?string $value): self
     {
         $new = clone $this;
-        $new->id = $value;
+        $new->attributes['id'] = $value;
         return $new;
     }
 
@@ -476,7 +475,12 @@ final class Alert extends Widget
     private function renderAlert(): string
     {
         $new = clone $this;
-        $new->attributes['id'] ??= $new->id ?? Html::generateId('alert-');
+
+        $div = Div::tag();
+
+        if (!array_key_exists('id', $this->attributes)) {
+            $div->id(Html::generateId('alert-'));
+        }
 
         if (!isset($new->parts['{button}'])) {
             $new->renderCloseButton($new);
@@ -497,7 +501,7 @@ final class Alert extends Widget
         $contentAlert = $new->renderPanelHeader($new) . PHP_EOL . $new->renderPanelBody($new);
 
         return $new->body !== ''
-            ? Div::tag()
+            ? $div
                 ->attribute('role', 'alert')
                 ->attributes($new->attributes)
                 ->content(PHP_EOL . trim($contentAlert) . PHP_EOL)

--- a/tests/AlertTest.php
+++ b/tests/AlertTest.php
@@ -93,7 +93,6 @@ final class AlertTest extends TestCase
                 ->buttonAttributes(['data-bs-dismiss' => 'alert', 'aria-label' => 'Close'])
                 ->buttonClass('btn-close')
                 ->buttonLabel()
-                ->buttonOnClick()
                 ->class('alert alert-success alert-dismissible fade show')
                 ->id('w0-alert')
                 ->header('Well done!')
@@ -125,7 +124,6 @@ final class AlertTest extends TestCase
                 ->buttonAttributes(['data-bs-dismiss' => 'alert', 'aria-label' => 'Close'])
                 ->buttonClass('btn-close')
                 ->buttonLabel()
-                ->buttonOnClick()
                 ->class('alert alert-warning alert-dismissible fade show')
                 ->id('w0-alert')
                 ->render(),
@@ -157,7 +155,6 @@ final class AlertTest extends TestCase
                 ->buttonAttributes(['data-bs-dismiss' => 'alert', 'aria-label' => 'Close'])
                 ->buttonClass('btn-close')
                 ->buttonLabel()
-                ->buttonOnClick()
                 ->class('alert alert-primary alert-dismissible fade show')
                 ->iconClass('bi bi-exclamation-triangle-fill flex-shrink-0 me-2')
                 ->id('w0-alert')
@@ -189,7 +186,6 @@ final class AlertTest extends TestCase
                 ->buttonAttributes(['data-bs-dismiss' => 'alert', 'aria-label' => 'Close'])
                 ->buttonClass('float-right')
                 ->buttonLabel()
-                ->buttonOnClick()
                 ->class('alert alert-primary')
                 ->id('w0-alert')
                 ->render(),

--- a/tests/AlertTest.php
+++ b/tests/AlertTest.php
@@ -561,6 +561,7 @@ final class AlertTest extends TestCase
         $this->assertEqualsWithoutLE(
             $expected,
             Alert::widget()
+                ->attributes(['id' => 'w0-alert'])
                 ->body(
                     '<p class="font-bold">Our privacy policy has changed</p>' .
                     '<p class="text-sm">Make sure you know how these changes affect you.</p>'
@@ -574,7 +575,6 @@ final class AlertTest extends TestCase
                 ->iconClass('not-italic')
                 ->iconContainerClass('fill-current h-6 mr-4 py-1 text-green-500 w-6')
                 ->iconText('🛈')
-                ->id('w0-alert')
                 ->layoutBody('{icon}{body}{button}')
                 ->render(),
         );

--- a/tests/AlertTest.php
+++ b/tests/AlertTest.php
@@ -48,8 +48,8 @@ final class AlertTest extends TestCase
             $expected,
             Alert::widget()
                 ->body('This is a test.')
-                ->bodyContainer()
                 ->bodyContainerAttributes(['class' => 'test-class'])
+                ->bodyContainerPanel(true)
                 ->id('w0-alert')
                 ->render(),
         );
@@ -62,7 +62,24 @@ final class AlertTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Body tag must be a string and cannot be empty.');
-        Alert::widget()->bodyTag('');
+        Alert::widget()->bodyContainer('');
+    }
+
+    /**
+     * @throws InvalidConfigException
+     */
+    public function testBodyWithoutTag(): void
+    {
+        $expected = <<<'HTML'
+        <div id="w0-alert" role="alert">
+        This is a test.
+        <button type="button">&times;</button>
+        </div>
+        HTML;
+        $this->assertEqualsWithoutLE(
+            $expected,
+            Alert::widget()->body('This is a test.')->bodyContainer(null)->id('w0-alert')->render(),
+        );
     }
 
     /**
@@ -120,7 +137,6 @@ final class AlertTest extends TestCase
             $expected,
             Alert::widget()
                 ->body('<strong>Holy guacamole!</strong> You should check in on some of those fields below.')
-                ->bodyContainerClass('align-items-center d-flex')
                 ->buttonAttributes(['data-bs-dismiss' => 'alert', 'aria-label' => 'Close'])
                 ->buttonClass('btn-close')
                 ->buttonLabel()
@@ -150,10 +166,10 @@ final class AlertTest extends TestCase
             $expected,
             Alert::widget()
                 ->body('An example alert with an icon')
-                ->bodyContainer()
                 ->bodyContainerClass('align-items-center d-flex')
                 ->buttonAttributes(['data-bs-dismiss' => 'alert', 'aria-label' => 'Close'])
                 ->buttonClass('btn-close')
+                ->bodyContainerPanel(true)
                 ->buttonLabel()
                 ->class('alert alert-primary alert-dismissible fade show')
                 ->iconClass('bi bi-exclamation-triangle-fill flex-shrink-0 me-2')
@@ -331,8 +347,8 @@ final class AlertTest extends TestCase
             $expected,
             Alert::widget()
                 ->body('An example alert with an icon.')
-                ->bodyContainer()
                 ->bodyContainerClass('is-flex is-align-items-center')
+                ->bodyContainerPanel(true)
                 ->buttonClass('delete')
                 ->class('notification is-danger')
                 ->iconClass('fa-2x fas fa-exclamation-circle mr-4')
@@ -429,8 +445,8 @@ final class AlertTest extends TestCase
             Alert::widget()
                 ->body('Get the coolest t-shirts from our brand new store')
                 ->bodyClass('flex-auto font-semibold mr-2 text-left')
-                ->bodyContainer()
                 ->bodyContainerClass('bg-gray-800 p-2 flex items-center leading-none lg:inline-flex lg:rounded-full')
+                ->bodyContainerPanel(true)
                 ->buttonClass('bottom-0 px-4 py-3 right-0 top-0')
                 ->buttonOnClick('closeAlert()')
                 ->class('bg-gray-900 lg:px-4 py-4 text-center text-white')
@@ -463,7 +479,7 @@ final class AlertTest extends TestCase
             Alert::widget()
                 ->body('Something happened that you should know about.')
                 ->bodyClass('align-middle flex-grow inline-block mr-8')
-                ->bodyTag('p')
+                ->bodyContainer('p')
                 ->buttonClass('float-right px-4 py-3')
                 ->buttonOnClick('closeAlert()')
                 ->class('bg-blue-500 flex font-bold items-center px-4 py-3 text-sm text-white')
@@ -524,15 +540,15 @@ final class AlertTest extends TestCase
             Alert::widget()
                 ->body('Something not ideal might be happening.')
                 ->bodyClass('align-middle inline-block mr-8 px-4 py-3')
-                ->bodyContainer()
                 ->bodyContainerClass('bg-red-100 border border-red-400 border-t-0 rounded-b text-red-700')
+                ->bodyContainerPanel(true)
                 ->buttonClass('float-right px-4 py-3')
                 ->buttonOnClick('closeAlert()')
-                ->id('w0-alert')
                 ->header('Danger')
                 ->headerClass('font-semibold')
                 ->headerContainer()
                 ->headerContainerClass('bg-red-500 font-bold px-4 py-2 rounded-t text-white')
+                ->id('w0-alert')
                 ->layoutHeader('{header}')
                 ->render(),
         );
@@ -563,8 +579,8 @@ final class AlertTest extends TestCase
                     '<p class="text-sm">Make sure you know how these changes affect you.</p>'
                 )
                 ->bodyClass('align-middle inline-block flex-grow mr-8')
-                ->bodyContainer()
                 ->bodyContainerClass('flex')
+                ->bodyContainerPanel(true)
                 ->buttonClass('float-right px-4 py-3')
                 ->buttonOnClick('closeAlert()')
                 ->class('bg-green-100 border-t-4 border-green-500 px-4 py-3 rounded-b shadow-md text-green-900')
@@ -574,5 +590,16 @@ final class AlertTest extends TestCase
                 ->layoutBody('{icon}{body}{button}')
                 ->render(),
         );
+    }
+
+    public function testGenerateId(): void
+    {
+        $expected = <<<'HTML'
+        <div id="alert-1" role="alert">
+        <span>This is a test.</span>
+        <button type="button">&times;</button>
+        </div>
+        HTML;
+        $this->assertEqualsWithoutLE($expected, Alert::widget()->body('This is a test.')->render());
     }
 }

--- a/tests/AlertTest.php
+++ b/tests/AlertTest.php
@@ -48,8 +48,8 @@ final class AlertTest extends TestCase
             $expected,
             Alert::widget()
                 ->body('This is a test.')
+                ->bodyContainer(true)
                 ->bodyContainerAttributes(['class' => 'test-class'])
-                ->bodyContainerPanel(true)
                 ->id('w0-alert')
                 ->render(),
         );
@@ -62,7 +62,7 @@ final class AlertTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Body tag must be a string and cannot be empty.');
-        Alert::widget()->bodyContainer('');
+        Alert::widget()->bodyTag('');
     }
 
     /**
@@ -78,7 +78,7 @@ final class AlertTest extends TestCase
         HTML;
         $this->assertEqualsWithoutLE(
             $expected,
-            Alert::widget()->body('This is a test.')->bodyContainer(null)->id('w0-alert')->render(),
+            Alert::widget()->body('This is a test.')->bodyTag(null)->id('w0-alert')->render(),
         );
     }
 
@@ -168,8 +168,8 @@ final class AlertTest extends TestCase
                 ->body('An example alert with an icon')
                 ->bodyContainerClass('align-items-center d-flex')
                 ->buttonAttributes(['data-bs-dismiss' => 'alert', 'aria-label' => 'Close'])
+                ->bodyContainer(true)
                 ->buttonClass('btn-close')
-                ->bodyContainerPanel(true)
                 ->buttonLabel()
                 ->class('alert alert-primary alert-dismissible fade show')
                 ->iconClass('bi bi-exclamation-triangle-fill flex-shrink-0 me-2')
@@ -347,8 +347,8 @@ final class AlertTest extends TestCase
             $expected,
             Alert::widget()
                 ->body('An example alert with an icon.')
+                ->bodyContainer(true)
                 ->bodyContainerClass('is-flex is-align-items-center')
-                ->bodyContainerPanel(true)
                 ->buttonClass('delete')
                 ->class('notification is-danger')
                 ->iconClass('fa-2x fas fa-exclamation-circle mr-4')
@@ -445,8 +445,8 @@ final class AlertTest extends TestCase
             Alert::widget()
                 ->body('Get the coolest t-shirts from our brand new store')
                 ->bodyClass('flex-auto font-semibold mr-2 text-left')
+                ->bodyContainer(true)
                 ->bodyContainerClass('bg-gray-800 p-2 flex items-center leading-none lg:inline-flex lg:rounded-full')
-                ->bodyContainerPanel(true)
                 ->buttonClass('bottom-0 px-4 py-3 right-0 top-0')
                 ->buttonOnClick('closeAlert()')
                 ->class('bg-gray-900 lg:px-4 py-4 text-center text-white')
@@ -479,7 +479,7 @@ final class AlertTest extends TestCase
             Alert::widget()
                 ->body('Something happened that you should know about.')
                 ->bodyClass('align-middle flex-grow inline-block mr-8')
-                ->bodyContainer('p')
+                ->bodyTag('p')
                 ->buttonClass('float-right px-4 py-3')
                 ->buttonOnClick('closeAlert()')
                 ->class('bg-blue-500 flex font-bold items-center px-4 py-3 text-sm text-white')
@@ -540,8 +540,8 @@ final class AlertTest extends TestCase
             Alert::widget()
                 ->body('Something not ideal might be happening.')
                 ->bodyClass('align-middle inline-block mr-8 px-4 py-3')
+                ->bodyContainer(true)
                 ->bodyContainerClass('bg-red-100 border border-red-400 border-t-0 rounded-b text-red-700')
-                ->bodyContainerPanel(true)
                 ->buttonClass('float-right px-4 py-3')
                 ->buttonOnClick('closeAlert()')
                 ->header('Danger')
@@ -579,8 +579,8 @@ final class AlertTest extends TestCase
                     '<p class="text-sm">Make sure you know how these changes affect you.</p>'
                 )
                 ->bodyClass('align-middle inline-block flex-grow mr-8')
+                ->bodyContainer(true)
                 ->bodyContainerClass('flex')
-                ->bodyContainerPanel(true)
                 ->buttonClass('float-right px-4 py-3')
                 ->buttonOnClick('closeAlert()')
                 ->class('bg-green-100 border-t-4 border-green-500 px-4 py-3 rounded-b shadow-md text-green-900')

--- a/tests/AlertTest.php
+++ b/tests/AlertTest.php
@@ -1,0 +1,582 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Yii\Widgets\Tests;
+
+use InvalidArgumentException;
+use Yiisoft\Definitions\Exception\InvalidConfigException;
+use Yiisoft\Yii\Widgets\Alert;
+
+final class AlertTest extends TestCase
+{
+    /**
+     * @throws InvalidConfigException
+     */
+    public function testBodyAttributes(): void
+    {
+        $expected = <<<'HTML'
+        <div id="w0-alert" role="alert">
+        <span class="test-class">This is a test.</span>
+        <button type="button">&times;</button>
+        </div>
+        HTML;
+        $this->assertEqualsWithoutLE(
+            $expected,
+            Alert::widget()
+                ->body('This is a test.')
+                ->bodyAttributes(['class' => 'test-class'])
+                ->id('w0-alert')
+                ->render(),
+        );
+    }
+
+    /**
+     * @throws InvalidConfigException
+     */
+    public function testBodyContainerAttributes(): void
+    {
+        $expected = <<<'HTML'
+        <div id="w0-alert" role="alert">
+        <div class="test-class">
+        <span>This is a test.</span>
+        <button type="button">&times;</button>
+        </div>
+        </div>
+        HTML;
+        $this->assertEqualsWithoutLE(
+            $expected,
+            Alert::widget()
+                ->body('This is a test.')
+                ->bodyContainer()
+                ->bodyContainerAttributes(['class' => 'test-class'])
+                ->id('w0-alert')
+                ->render(),
+        );
+    }
+
+    /**
+     * @throws InvalidConfigException
+     */
+    public function testBodyTagException(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Body tag must be a string and cannot be empty.');
+        Alert::widget()->bodyTag('');
+    }
+
+    /**
+     * @link https://getbootstrap.com/docs/5.0/components/alerts/#additional-content
+     *
+     * @throws InvalidConfigException
+     */
+    public function testBootstrap5AditionalContent(): void
+    {
+        $expected = <<<'HTML'
+        <div id="w0-alert" class="alert alert-success alert-dismissible fade show" role="alert">
+        <h4 class="alert-heading">Well done!</h4>
+        <span><p>Aww yeah, you successfully read this important alert message. This example text is going to run a bit longer so that you can see how spacing within an alert works with this kind of content.</p>
+        <hr>
+        <p class="mb-0">Whenever you need to, be sure to use margin utilities to keep things nice and tidy</p></span>
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+        </div>
+        HTML;
+        $this->assertEqualsWithoutLE(
+            $expected,
+            Alert::widget()
+                ->body(
+                    '<p>Aww yeah, you successfully read this important alert message. This example text is going to run ' .
+                    'a bit longer so that you can see how spacing within an alert works with this kind of content.</p>' .
+                    PHP_EOL . '<hr>' . PHP_EOL .
+                    '<p class="mb-0">Whenever you need to, be sure to use margin utilities to keep things nice and tidy</p>'
+                )
+                ->buttonAttributes(['data-bs-dismiss' => 'alert', 'aria-label' => 'Close'])
+                ->buttonClass('btn-close')
+                ->buttonLabel()
+                ->buttonOnClick()
+                ->class('alert alert-success alert-dismissible fade show')
+                ->id('w0-alert')
+                ->header('Well done!')
+                ->headerClass('alert-heading')
+                ->headerTag('h4')
+                ->layoutHeader('{header}')
+                ->render(),
+        );
+    }
+
+    /**
+     * @link https://getbootstrap.com/docs/5.0/components/alerts/#dismissing
+     *
+     * @throws InvalidConfigException
+     */
+    public function testBootstrap5Dismising(): void
+    {
+        $expected = <<<'HTML'
+        <div id="w0-alert" class="alert alert-warning alert-dismissible fade show" role="alert">
+        <span><strong>Holy guacamole!</strong> You should check in on some of those fields below.</span>
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+        </div>
+        HTML;
+        $this->assertEqualsWithoutLE(
+            $expected,
+            Alert::widget()
+                ->body('<strong>Holy guacamole!</strong> You should check in on some of those fields below.')
+                ->bodyContainerClass('align-items-center d-flex')
+                ->buttonAttributes(['data-bs-dismiss' => 'alert', 'aria-label' => 'Close'])
+                ->buttonClass('btn-close')
+                ->buttonLabel()
+                ->buttonOnClick()
+                ->class('alert alert-warning alert-dismissible fade show')
+                ->id('w0-alert')
+                ->render(),
+        );
+    }
+
+    /**
+     * @link https://getbootstrap.com/docs/5.0/components/alerts/#icons
+     *
+     * @throws InvalidConfigException
+     */
+    public function testBootstrap5Icon(): void
+    {
+        $expected = <<<'HTML'
+        <div id="w0-alert" class="alert alert-primary alert-dismissible fade show" role="alert">
+        <div class="align-items-center d-flex">
+        <div><i class="bi bi-exclamation-triangle-fill flex-shrink-0 me-2"></i></div>
+        <span>An example alert with an icon</span>
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+        </div>
+        </div>
+        HTML;
+        $this->assertEqualsWithoutLE(
+            $expected,
+            Alert::widget()
+                ->body('An example alert with an icon')
+                ->bodyContainer()
+                ->bodyContainerClass('align-items-center d-flex')
+                ->buttonAttributes(['data-bs-dismiss' => 'alert', 'aria-label' => 'Close'])
+                ->buttonClass('btn-close')
+                ->buttonLabel()
+                ->buttonOnClick()
+                ->class('alert alert-primary alert-dismissible fade show')
+                ->iconClass('bi bi-exclamation-triangle-fill flex-shrink-0 me-2')
+                ->id('w0-alert')
+                ->layoutBody('{icon}{body}{button}')
+                ->render(),
+        );
+    }
+
+    /**
+     * @link https://getbootstrap.com/docs/5.0/components/alerts/#link-color
+     *
+     * @throws InvalidConfigException
+     */
+    public function testBootstrap5LinkColor(): void
+    {
+        $expected = <<<'HTML'
+        <div id="w0-alert" class="alert alert-primary" role="alert">
+        <span>A simple primary alert with <a href="#" class="alert-link">an example link</a>.Give it a click if you like.</span>
+        <button type="button" class="float-right" data-bs-dismiss="alert" aria-label="Close"></button>
+        </div>
+        HTML;
+        $this->assertEqualsWithoutLE(
+            $expected,
+            Alert::widget()
+                ->body(
+                    'A simple primary alert with <a href="#" class="alert-link">an example link</a>.' .
+                    'Give it a click if you like.'
+                )
+                ->buttonAttributes(['data-bs-dismiss' => 'alert', 'aria-label' => 'Close'])
+                ->buttonClass('float-right')
+                ->buttonLabel()
+                ->buttonOnClick()
+                ->class('alert alert-primary')
+                ->id('w0-alert')
+                ->render(),
+        );
+    }
+
+    /**
+     * @throws InvalidConfigException
+     */
+    public function testHeaderAttributes(): void
+    {
+        $expected = <<<'HTML'
+        <div id="w0-alert" role="alert">
+        <span class="tests-class">Header title</span>
+        <span>This is a test.</span>
+        <button type="button">&times;</button>
+        </div>
+        HTML;
+        $this->assertEqualsWithoutLE(
+            $expected,
+            Alert::widget()
+                ->body('This is a test.')
+                ->header('Header title')
+                ->headerAttributes(['class' => 'tests-class'])
+                ->id('w0-alert')
+                ->layoutHeader('{header}')
+                ->render(),
+        );
+    }
+
+    /**
+     * @throws InvalidConfigException
+     */
+    public function testHeaderContainerAttributes(): void
+    {
+        $expected = <<<'HTML'
+        <div id="w0-alert" role="alert">
+        <div class="test-class">
+        <span>Header title</span>
+        </div>
+        <span>This is a test.</span>
+        <button type="button">&times;</button>
+        </div>
+        HTML;
+        $this->assertEqualsWithoutLE(
+            $expected,
+            Alert::widget()
+                ->body('This is a test.')
+                ->header('Header title')
+                ->headerContainer()
+                ->headerContainerAttributes(['class' => 'test-class'])
+                ->id('w0-alert')
+                ->layoutHeader('{header}')
+                ->render(),
+        );
+    }
+
+    /**
+     * @throws InvalidConfigException
+     */
+    public function testIconAttributes(): void
+    {
+        $expected = <<<'HTML'
+        <div id="w0-alert" role="alert">
+        <div><i class="tests-class"></i></div>
+        <span>This is a test.</span>
+        </div>
+        HTML;
+        $this->assertEqualsWithoutLE(
+            $expected,
+            Alert::widget()
+                ->body('This is a test.')
+                ->iconAttributes(['class' => 'tests-class'])
+                ->id('w0-alert')
+                ->layoutBody('{icon}{body}')
+                ->render()
+        );
+    }
+
+    /**
+     * @throws InvalidConfigException
+     */
+    public function testIconContainerAttributes(): void
+    {
+        $expected = <<<'HTML'
+        <div id="w0-alert" role="alert">
+        <div class="test-container-class"><i class="tests-class"></i></div>
+        <span>This is a test.</span>
+        </div>
+        HTML;
+        $this->assertEqualsWithoutLE(
+            $expected,
+            Alert::widget()
+                ->body('This is a test.')
+                ->iconAttributes(['class' => 'tests-class'])
+                ->iconContainerAttributes(['class' => 'test-container-class'])
+                ->id('w0-alert')
+                ->layoutBody('{icon}{body}')
+                ->render(),
+        );
+    }
+
+    /**
+     * @link https://bulma.io/documentation/elements/notification/
+     *
+     * @throws InvalidConfigException
+     */
+    public function testNotificationBulma(): void
+    {
+        $expected = <<<'HTML'
+        <div id="w0-alert" class="notification is-danger" role="alert">
+        <span>An example alert with an icon.</span>
+        <button type="button" class="delete">&times;</button>
+        </div>
+        HTML;
+        $this->assertEqualsWithoutLE(
+            $expected,
+            Alert::widget()
+                ->body('An example alert with an icon.')
+                ->buttonClass('delete')
+                ->class('notification is-danger')
+                ->id('w0-alert')
+                ->layoutBody('{body}{button}')
+                ->render(),
+        );
+    }
+
+    /**
+     * @throws InvalidConfigException
+     */
+    public function testNotificationWithIconBulma(): void
+    {
+        $expected = <<<'HTML'
+        <div id="w0-alert" class="notification is-danger" role="alert">
+        <button type="button" class="delete">&times;</button>
+        <div class="is-flex is-align-items-center">
+        <div><i class="fa-2x fas fa-exclamation-circle mr-4"></i></div>
+        <span>An example alert with an icon.</span>
+        </div>
+        </div>
+        HTML;
+        $this->assertEqualsWithoutLE(
+            $expected,
+            Alert::widget()
+                ->body('An example alert with an icon.')
+                ->bodyContainer()
+                ->bodyContainerClass('is-flex is-align-items-center')
+                ->buttonClass('delete')
+                ->class('notification is-danger')
+                ->iconClass('fa-2x fas fa-exclamation-circle mr-4')
+                ->id('w0-alert')
+                ->layoutBody('{icon}{body}')
+                ->layoutHeader('{button}')
+                ->render(),
+        );
+    }
+
+    /**
+     * @throws InvalidConfigException
+     */
+    public function testHeaderTagException(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Header tag must be a string and cannot be empty.');
+        Alert::widget()->headerTag('');
+    }
+
+    /**
+     * @link https://v1.tailwindcss.com/components/alerts#banner
+     *
+     * @throws InvalidConfigException
+     */
+    public function testTailwindBanner(): void
+    {
+        $expected = <<<'HTML'
+        <div id="w0-alert" class="bg-blue-100 border-b border-blue-500 border-t px-4 py-3 text-blue-700" role="alert">
+        <span class="align-middle inline-block mr-8"><p class="font-bold">Informational message</p><p class="text-sm">Some additional text to explain said message.</p></span>
+        <button type="button" class="float-right px-4 py-3" onclick="closeAlert()">&times;</button>
+        </div>
+        HTML;
+        $this->assertEqualsWithoutLE(
+            $expected,
+            Alert::widget()
+                ->body(
+                    '<p class="font-bold">Informational message</p>' .
+                    '<p class="text-sm">Some additional text to explain said message.</p>'
+                )
+                ->bodyClass('align-middle inline-block mr-8')
+                ->buttonClass('float-right px-4 py-3')
+                ->buttonOnClick('closeAlert()')
+                ->class('bg-blue-100 border-b border-blue-500 border-t px-4 py-3 text-blue-700')
+                ->id('w0-alert')
+                ->render(),
+        );
+    }
+
+    /**
+     * @link https://v1.tailwindcss.com/components/alerts#left-accent-border
+     *
+     * @throws InvalidConfigException
+     */
+    public function testTailwindLeftAccentBorder(): void
+    {
+        $expected = <<<'HTML'
+        <div id="w0-alert" class="bg-yellow-100 border-l-2 border-yellow-500 p-4 text-yellow-700" role="alert">
+        <span class="align-middle inline-block mr-8"><p><b>Be Warned</b></p> <p>Something not ideal might be happening.</p></span>
+        <button type="button" class="absolute bottom-0 px-4 py-3 right-0 top-0" onclick="closeAlert()">&times;</button>
+        </div>
+        HTML;
+        $this->assertEqualsWithoutLE(
+            $expected,
+            Alert::widget()
+                ->body('<p><b>Be Warned</b></p> <p>Something not ideal might be happening.</p>')
+                ->bodyClass('align-middle inline-block mr-8')
+                ->buttonClass('absolute bottom-0 px-4 py-3 right-0 top-0')
+                ->buttonOnClick('closeAlert()')
+                ->class('bg-yellow-100 border-l-2 border-yellow-500 p-4 text-yellow-700')
+                ->id('w0-alert')
+                ->render(),
+        );
+    }
+
+    /**
+     * @link https://v1.tailwindcss.com/components/alerts#modern-with-badge
+     *
+     * @throws InvalidConfigException
+     */
+    public function testTailwindModernWithBadge(): void
+    {
+        $expected = <<<'HTML'
+        <div id="w0-alert" class="bg-gray-900 lg:px-4 py-4 text-center text-white" role="alert">
+        <button type="button" class="bottom-0 px-4 py-3 right-0 top-0" onclick="closeAlert()">&times;</button>
+        <div class="bg-gray-800 p-2 flex items-center leading-none lg:inline-flex lg:rounded-full">
+        <div class="bg-gray-500 flex font-bold ml-2 mr-3 px-2 py-1 rounded-full text-xs uppercase"><i class="not-italic">🔔 New </i></div>
+        <span class="flex-auto font-semibold mr-2 text-left">Get the coolest t-shirts from our brand new store</span>
+        </div>
+        </div>
+        HTML;
+        $this->assertEqualsWithoutLE(
+            $expected,
+            Alert::widget()
+                ->body('Get the coolest t-shirts from our brand new store')
+                ->bodyClass('flex-auto font-semibold mr-2 text-left')
+                ->bodyContainer()
+                ->bodyContainerClass('bg-gray-800 p-2 flex items-center leading-none lg:inline-flex lg:rounded-full')
+                ->buttonClass('bottom-0 px-4 py-3 right-0 top-0')
+                ->buttonOnClick('closeAlert()')
+                ->class('bg-gray-900 lg:px-4 py-4 text-center text-white')
+                ->iconClass('not-italic')
+                ->iconContainerClass('bg-gray-500 flex font-bold ml-2 mr-3 px-2 py-1 rounded-full text-xs uppercase')
+                ->iconText('🔔 New ')
+                ->id('w0-alert')
+                ->layoutBody('{icon}{body}')
+                ->layoutHeader('{button}')
+                ->render(),
+        );
+    }
+
+    /**
+     * @link https://v1.tailwindcss.com/components/alerts#solid
+     *
+     * @throws InvalidConfigException
+     */
+    public function testTailwindSolid(): void
+    {
+        $expected = <<<'HTML'
+        <div id="w0-alert" class="bg-blue-500 flex font-bold items-center px-4 py-3 text-sm text-white" role="alert">
+        <div><i class="pr-2">i</i></div>
+        <p class="align-middle flex-grow inline-block mr-8">Something happened that you should know about.</p>
+        <button type="button" class="float-right px-4 py-3" onclick="closeAlert()">&times;</button>
+        </div>
+        HTML;
+        $this->assertEqualsWithoutLE(
+            $expected,
+            Alert::widget()
+                ->body('Something happened that you should know about.')
+                ->bodyClass('align-middle flex-grow inline-block mr-8')
+                ->bodyTag('p')
+                ->buttonClass('float-right px-4 py-3')
+                ->buttonOnClick('closeAlert()')
+                ->class('bg-blue-500 flex font-bold items-center px-4 py-3 text-sm text-white')
+                ->iconClass('pr-2')
+                ->iconText('i')
+                ->id('w0-alert')
+                ->layoutBody('{icon}{body}{button}')
+                ->render(),
+        );
+    }
+
+    /**
+     * @link https://v1.tailwindcss.com/components/alerts#traditional
+     *
+     * @throws InvalidConfigException
+     */
+    public function testTailwindTraditional(): void
+    {
+        $expected = <<<'HTML'
+        <div id="w0-alert" class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative" role="alert">
+        <span class="align-middle inline-block mr-8"><b>Holy smokes!</b> Something seriously bad happened.</span>
+        <button type="button" class="absolute bottom-0 px-4 py-3 right-0 top-0" onclick="closeAlert()">&times;</button>
+        </div>
+        HTML;
+        $this->assertEqualsWithoutLE(
+            $expected,
+            Alert::widget()
+                ->body('<b>Holy smokes!</b> Something seriously bad happened.')
+                ->bodyClass('align-middle inline-block mr-8')
+                ->buttonClass('absolute bottom-0 px-4 py-3 right-0 top-0')
+                ->buttonOnClick('closeAlert()')
+                ->class('bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative')
+                ->id('w0-alert')
+                ->render(),
+        );
+    }
+
+    /**
+     * @link https://v1.tailwindcss.com/components/alerts#titled
+     *
+     * @throws InvalidConfigException
+     */
+    public function testTailwindTitled(): void
+    {
+        $expected = <<<'HTML'
+        <div id="w0-alert" role="alert">
+        <div class="bg-red-500 font-bold px-4 py-2 rounded-t text-white">
+        <span class="font-semibold">Danger</span>
+        </div>
+        <div class="bg-red-100 border border-red-400 border-t-0 rounded-b text-red-700">
+        <span class="align-middle inline-block mr-8 px-4 py-3">Something not ideal might be happening.</span>
+        <button type="button" class="float-right px-4 py-3" onclick="closeAlert()">&times;</button>
+        </div>
+        </div>
+        HTML;
+        $this->assertEqualsWithoutLE(
+            $expected,
+            Alert::widget()
+                ->body('Something not ideal might be happening.')
+                ->bodyClass('align-middle inline-block mr-8 px-4 py-3')
+                ->bodyContainer()
+                ->bodyContainerClass('bg-red-100 border border-red-400 border-t-0 rounded-b text-red-700')
+                ->buttonClass('float-right px-4 py-3')
+                ->buttonOnClick('closeAlert()')
+                ->id('w0-alert')
+                ->header('Danger')
+                ->headerClass('font-semibold')
+                ->headerContainer()
+                ->headerContainerClass('bg-red-500 font-bold px-4 py-2 rounded-t text-white')
+                ->layoutHeader('{header}')
+                ->render(),
+        );
+    }
+
+    /**
+     * @link https://v1.tailwindcss.com/components/alerts#top-accent-border
+     *
+     * @throws InvalidConfigException
+     */
+    public function testTailwindTopAccentBorder(): void
+    {
+        $expected = <<<'HTML'
+        <div id="w0-alert" class="bg-green-100 border-t-4 border-green-500 px-4 py-3 rounded-b shadow-md text-green-900" role="alert">
+        <div class="flex">
+        <div class="fill-current h-6 mr-4 py-1 text-green-500 w-6"><i class="not-italic">🛈</i></div>
+        <span class="align-middle inline-block flex-grow mr-8"><p class="font-bold">Our privacy policy has changed</p><p class="text-sm">Make sure you know how these changes affect you.</p></span>
+        <button type="button" class="float-right px-4 py-3" onclick="closeAlert()">&times;</button>
+        </div>
+        </div>
+        HTML;
+        $this->assertEqualsWithoutLE(
+            $expected,
+            Alert::widget()
+                ->body(
+                    '<p class="font-bold">Our privacy policy has changed</p>' .
+                    '<p class="text-sm">Make sure you know how these changes affect you.</p>'
+                )
+                ->bodyClass('align-middle inline-block flex-grow mr-8')
+                ->bodyContainer()
+                ->bodyContainerClass('flex')
+                ->buttonClass('float-right px-4 py-3')
+                ->buttonOnClick('closeAlert()')
+                ->class('bg-green-100 border-t-4 border-green-500 px-4 py-3 rounded-b shadow-md text-green-900')
+                ->iconClass('not-italic')
+                ->iconContainerClass('fill-current h-6 mr-4 py-1 text-green-500 w-6')
+                ->iconText('🛈')
+                ->id('w0-alert')
+                ->layoutBody('{icon}{body}{button}')
+                ->render(),
+        );
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -84,3 +84,9 @@ abstract class TestCase extends BaseTestCase
         ];
     }
 }
+
+namespace Yiisoft\Html;
+
+function hrtime(bool $getAsNumber = false): void
+{
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌

Add widget alert support `Bootstrap5`, `Bulma`, `Tailwind`.
