### PR TITLE
Use ol tag as default

### DIFF
--- a/src/Breadcrumbs.php
+++ b/src/Breadcrumbs.php
@@ -55,7 +55,7 @@ final class Breadcrumbs extends Widget
     private array|null $homeItem = ['label' => 'Home', 'url' => '/'];
     private array $items = [];
     private string $itemTemplate = "<li>{link}</li>\n";
-    private string $tag = 'ul';
+    private string $tag = 'ol';
 
     /**
      * Returns a new instance with the specified active item template.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | none

OL is more semantic than UL; breadcrumbs are, by definition, ordered.