### PR TITLE
Fix #110: Allow to set `View` or `WebView` instance for `ContentDecorator` via `view()` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Chg #105: Raise the minimum PHP version to `8.1` (@rustamwin)
 - Chg #105: Change PHP constraint in `composer.json` to `8.1 - 8.5` (@rustamwin)
 - Enh #108: Bump minimal `yiisoft/html` version to `3.13` and add support for `^4.0` (@vjik)
+- Enh #110: Allow to set `View` or `WebView` instance for `ContentDecorator` via `view()` method (@WarLikeLaux)
 
 ## 2.1.1 September 23, 2025
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Chg #105: Raise the minimum PHP version to `8.1` (@rustamwin)
 - Chg #105: Change PHP constraint in `composer.json` to `8.1 - 8.5` (@rustamwin)
 - Enh #108: Bump minimal `yiisoft/html` version to `3.13` and add support for `^4.0` (@vjik)
-- Enh #110: Allow to set `View` or `WebView` instance for `ContentDecorator` via `view()` method (@WarLikeLaux)
+- New #110: Allow to set `View` or `WebView` instance for `ContentDecorator` via `view()` method (@WarLikeLaux)
 - Bug #113: Fix `array_merge()` argument order in `Menu::renderItem()` so that item-level `linkAttributes` override widget-level ones (@WarLikeLaux)
 
 ## 2.1.1 September 23, 2025

--- a/rector.php
+++ b/rector.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 use Rector\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector;
 use Rector\Config\RectorConfig;
-use Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
 
 return RectorConfig::configure()
     ->withPaths([
@@ -12,11 +11,6 @@ return RectorConfig::configure()
         __DIR__ . '/tests',
     ])
     ->withPhpSets(php81: true)
-    ->withSkip([
-        ClassPropertyAssignToConstructorPromotionRector::class => [
-            __DIR__ . '/src/ContentDecorator.php',
-        ],
-    ])
     ->withRules([
         InlineConstructorDefaultToPropertyRector::class,
     ]);

--- a/rector.php
+++ b/rector.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Rector\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector;
 use Rector\Config\RectorConfig;
+use Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
 
 return RectorConfig::configure()
     ->withPaths([
@@ -11,6 +12,11 @@ return RectorConfig::configure()
         __DIR__ . '/tests',
     ])
     ->withPhpSets(php81: true)
+    ->withSkip([
+        ClassPropertyAssignToConstructorPromotionRector::class => [
+            __DIR__ . '/src/ContentDecorator.php',
+        ],
+    ])
     ->withRules([
         InlineConstructorDefaultToPropertyRector::class,
     ]);

--- a/src/ContentDecorator.php
+++ b/src/ContentDecorator.php
@@ -7,6 +7,7 @@ namespace Yiisoft\Yii\Widgets;
 use Throwable;
 use Yiisoft\Aliases\Aliases;
 use Yiisoft\View\Exception\ViewNotFoundException;
+use Yiisoft\View\ViewInterface;
 use Yiisoft\View\WebView;
 use Yiisoft\Widget\Widget;
 
@@ -32,6 +33,7 @@ use function ob_start;
 final class ContentDecorator extends Widget
 {
     private array $parameters = [];
+    private ?ViewInterface $view = null;
     private string $viewFile = '';
 
     public function __construct(private Aliases $aliases, private WebView $webView) {}
@@ -45,6 +47,28 @@ final class ContentDecorator extends Widget
     {
         $new = clone $this;
         $new->parameters = $value;
+
+        return $new;
+    }
+
+    /**
+     * Returns a new instance with the specified view instance.
+     *
+     * Passing the view instance is needed to use current state (e.g., parameters) in the decorator view file.
+     *
+     * @param ViewInterface $view The view instance ({@see View} or {@see WebView}) to use for rendering.
+     * @param string $viewFile The view file that will be used to decorate the content enclosed by this widget.
+     * This can be specified as either the view file path or alias path. If empty, the view file
+     * set via {@see viewFile()} will be used.
+     */
+    public function view(ViewInterface $view, string $viewFile = ''): self
+    {
+        $new = clone $this;
+        $new->view = $view;
+
+        if ($viewFile !== '') {
+            $new->viewFile = $this->aliases->get($viewFile);
+        }
 
         return $new;
     }
@@ -90,7 +114,6 @@ final class ContentDecorator extends Widget
         $parameters = $this->parameters;
         $parameters['content'] = ob_get_clean();
 
-        /** render under the existing context */
-        return $this->webView->render($this->viewFile, $parameters);
+        return ($this->view ?? $this->webView)->render($this->viewFile, $parameters);
     }
 }

--- a/src/ContentDecorator.php
+++ b/src/ContentDecorator.php
@@ -33,10 +33,13 @@ use function ob_start;
 final class ContentDecorator extends Widget
 {
     private array $parameters = [];
-    private ?ViewInterface $view = null;
+    private ViewInterface $view;
     private string $viewFile = '';
 
-    public function __construct(private Aliases $aliases, private WebView $webView) {}
+    public function __construct(private Aliases $aliases, WebView $webView)
+    {
+        $this->view = $webView;
+    }
 
     /**
      * Returns a new instance with the specified parameters.
@@ -114,6 +117,6 @@ final class ContentDecorator extends Widget
         $parameters = $this->parameters;
         $parameters['content'] = ob_get_clean();
 
-        return ($this->view ?? $this->webView)->render($this->viewFile, $parameters);
+        return $this->view->render($this->viewFile, $parameters);
     }
 }

--- a/src/ContentDecorator.php
+++ b/src/ContentDecorator.php
@@ -35,9 +35,7 @@ final class ContentDecorator extends Widget
     private array $parameters = [];
     private string $viewFile = '';
 
-    public function __construct(private Aliases $aliases, private ViewInterface $view)
-    {
-    }
+    public function __construct(private Aliases $aliases, private ViewInterface $view) {}
 
     /**
      * Returns a new instance with the specified parameters.

--- a/src/ContentDecorator.php
+++ b/src/ContentDecorator.php
@@ -33,13 +33,9 @@ use function ob_start;
 final class ContentDecorator extends Widget
 {
     private array $parameters = [];
-    private ViewInterface $view;
     private string $viewFile = '';
 
-    public function __construct(private readonly Aliases $aliases, WebView $webView)
-    {
-        $this->view = $webView;
-    }
+    public function __construct(private readonly Aliases $aliases, private ViewInterface $view) {}
 
     /**
      * Returns a new instance with the specified parameters.

--- a/src/ContentDecorator.php
+++ b/src/ContentDecorator.php
@@ -33,12 +33,10 @@ use function ob_start;
 final class ContentDecorator extends Widget
 {
     private array $parameters = [];
-    private ViewInterface $view;
     private string $viewFile = '';
 
-    public function __construct(private Aliases $aliases, WebView $webView)
+    public function __construct(private Aliases $aliases, private ViewInterface $view)
     {
-        $this->view = $webView;
     }
 
     /**

--- a/src/ContentDecorator.php
+++ b/src/ContentDecorator.php
@@ -33,9 +33,13 @@ use function ob_start;
 final class ContentDecorator extends Widget
 {
     private array $parameters = [];
+    private ViewInterface $view;
     private string $viewFile = '';
 
-    public function __construct(private Aliases $aliases, private ViewInterface $view) {}
+    public function __construct(private Aliases $aliases, WebView $webView)
+    {
+        $this->view = $webView;
+    }
 
     /**
      * Returns a new instance with the specified parameters.

--- a/src/ContentDecorator.php
+++ b/src/ContentDecorator.php
@@ -33,9 +33,13 @@ use function ob_start;
 final class ContentDecorator extends Widget
 {
     private array $parameters = [];
+    private ViewInterface $view;
     private string $viewFile = '';
 
-    public function __construct(private readonly Aliases $aliases, private ViewInterface $view) {}
+    public function __construct(private readonly Aliases $aliases, ViewInterface $webView)
+    {
+        $this->view = $webView;
+    }
 
     /**
      * Returns a new instance with the specified parameters.

--- a/tests/ContentDecorator/ContentDecoratorTest.php
+++ b/tests/ContentDecorator/ContentDecoratorTest.php
@@ -9,6 +9,8 @@ use Yiisoft\Definitions\Exception\CircularReferenceException;
 use Yiisoft\Definitions\Exception\InvalidConfigException;
 use Yiisoft\Definitions\Exception\NotInstantiableException;
 use Yiisoft\Factory\NotFoundException;
+use Yiisoft\Test\Support\EventDispatcher\SimpleEventDispatcher;
+use Yiisoft\View\View;
 use Yiisoft\Yii\Widgets\ContentDecorator;
 use Yiisoft\Yii\Widgets\Tests\Support\Assert;
 use Yiisoft\Yii\Widgets\Tests\Support\TestTrait;
@@ -60,5 +62,45 @@ final class ContentDecoratorTest extends TestCase
             HTML,
             $html,
         );
+    }
+
+    public function testViewWithViewFile(): void
+    {
+        $view = new View(__DIR__ . '/../Support/view', new SimpleEventDispatcher());
+        $view->setParameter('title', 'Hello');
+
+        ContentDecorator::widget()
+            ->view($view, '@public/view/layout-simple.php')
+            ->begin();
+        echo 'body';
+        $html = ContentDecorator::end();
+
+        $this->assertSame('<main>Hellobody</main>', trim($html));
+    }
+
+    public function testViewWithSeparateViewFile(): void
+    {
+        $view = new View(__DIR__ . '/../Support/view', new SimpleEventDispatcher());
+
+        ContentDecorator::widget()
+            ->view($view)
+            ->viewFile('@public/view/layout-simple.php')
+            ->begin();
+        echo 'world';
+        $html = ContentDecorator::end();
+
+        $this->assertSame('<main>world</main>', trim($html));
+    }
+
+    public function testViewWithWebView(): void
+    {
+        ContentDecorator::widget()
+            ->view($this->webView, '@public/view/layout.php')
+            ->begin();
+        echo 'content';
+        $html = ContentDecorator::end();
+
+        $this->assertStringContainsString('content', $html);
+        $this->assertStringContainsString('<title>Test</title>', $html);
     }
 }

--- a/tests/ContentDecorator/ContentDecoratorTest.php
+++ b/tests/ContentDecorator/ContentDecoratorTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Yiisoft\Yii\Widgets\Tests\ContentDecorator;
 
 use PHPUnit\Framework\TestCase;
-use Yiisoft\Test\Support\EventDispatcher\SimpleEventDispatcher;
 use Yiisoft\View\View;
 use Yiisoft\Yii\Widgets\ContentDecorator;
 use Yiisoft\Yii\Widgets\Tests\Support\Assert;
@@ -54,7 +53,7 @@ final class ContentDecoratorTest extends TestCase
 
     public function testViewWithViewFile(): void
     {
-        $view = new View(__DIR__ . '/../Support/view', new SimpleEventDispatcher());
+        $view = new View(__DIR__ . '/../Support/view');
         $view->setParameter('title', 'Hello');
 
         ContentDecorator::widget()
@@ -68,7 +67,7 @@ final class ContentDecoratorTest extends TestCase
 
     public function testViewWithSeparateViewFile(): void
     {
-        $view = new View(__DIR__ . '/../Support/view', new SimpleEventDispatcher());
+        $view = new View(__DIR__ . '/../Support/view');
 
         ContentDecorator::widget()
             ->view($view)

--- a/tests/ContentDecorator/ImmutableTest.php
+++ b/tests/ContentDecorator/ImmutableTest.php
@@ -9,6 +9,7 @@ use Yiisoft\Definitions\Exception\CircularReferenceException;
 use Yiisoft\Definitions\Exception\InvalidConfigException;
 use Yiisoft\Definitions\Exception\NotInstantiableException;
 use Yiisoft\Factory\NotFoundException;
+use Yiisoft\View\View;
 use Yiisoft\Yii\Widgets\ContentDecorator;
 use Yiisoft\Yii\Widgets\Tests\Support\TestTrait;
 
@@ -29,6 +30,7 @@ final class ImmutableTest extends TestCase
     {
         $contentDecorator = ContentDecorator::widget();
         $this->assertNotSame($contentDecorator, $contentDecorator->parameters([]));
+        $this->assertNotSame($contentDecorator, $contentDecorator->view(new View()));
         $this->assertNotSame($contentDecorator, $contentDecorator->viewFile(''));
     }
 }

--- a/tests/Support/TestTrait.php
+++ b/tests/Support/TestTrait.php
@@ -10,6 +10,7 @@ use Yiisoft\Cache\CacheInterface;
 use Yiisoft\Test\Support\Container\SimpleContainer;
 use Yiisoft\Test\Support\EventDispatcher\SimpleEventDispatcher;
 use Yiisoft\Test\Support\SimpleCache\MemorySimpleCache;
+use Yiisoft\View\ViewInterface;
 use Yiisoft\View\WebView;
 use Yiisoft\Widget\WidgetFactory;
 
@@ -22,11 +23,14 @@ trait TestTrait
     {
         parent::setUp();
 
+        $webView = new WebView(__DIR__ . '/public/view', new SimpleEventDispatcher());
+
         $container = new SimpleContainer(
             [
                 Aliases::class => new Aliases(['@public' => __DIR__]),
                 CacheInterface::class => new Cache(new MemorySimpleCache()),
-                WebView::class => new WebView(__DIR__ . '/public/view', new SimpleEventDispatcher()),
+                ViewInterface::class => $webView,
+                WebView::class => $webView,
             ],
         );
 

--- a/tests/Support/view/layout-simple.php
+++ b/tests/Support/view/layout-simple.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+/* @var $this Yiisoft\View\ViewInterface */
+/* @var $content string */
+
+$title = $this->hasParameter('title') ? $this->getParameter('title') : '';
+?>
+<main><?= $title ?><?= $content ?></main>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Tests added?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | #100

## What does this PR do?

Adds `view(ViewInterface $view, string $viewFile = '')` method to `ContentDecorator`, allowing to pass a `View` or `WebView` instance with its current state (e.g., parameters) for rendering the decorator view file.

### Coverage

Tests: 2 → 5. Lines: 12/12 (100%) → 17/17 (100%). MSI: 100% (6/6) → 100% (10/10).
