### PR TITLE
Fix #115: Add container wrapper and JSON-LD structured data to `Breadcrumbs` widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Chg #105: Change PHP constraint in `composer.json` to `8.1 - 8.5` (@rustamwin)
 - Enh #108: Bump minimal `yiisoft/html` version to `3.13` and add support for `^4.0` (@vjik)
 - Bug #113: Fix `array_merge()` argument order in `Menu::renderItem()` so that item-level `linkAttributes` override widget-level ones (@WarLikeLaux)
+- New #117: Add container wrapper and JSON-LD structured data to `Breadcrumbs` widget (@WarLikeLaux)
 
 ## 2.1.1 September 23, 2025
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - New #126: Add `Menu::dropdownContainerAttributes()` method (@WarLikeLaux)
 - Bug #127: Fix `encode` key leaking into HTML attributes in `Breadcrumbs::renderItem()` (@WarLikeLaux)
 - New #129: Add `id()` method to `Menu` and `Breadcrumbs` widgets (@WarLikeLaux)
-- New #117: Add container wrapper and JSON-LD structured data to `Breadcrumbs` widget (@WarLikeLaux)
+- New #117: Add container wrapper and JSON-LD structured data to `Breadcrumbs` widget (@WarLikeLaux, @vjik)
 - Enh #155: Add `url` as alias for `link` in `Menu` and `Dropdown` items (@WarLikeLaux)
 
 ## 2.1.1 September 23, 2025

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 - New #126: Add `Menu::dropdownContainerAttributes()` method (@WarLikeLaux)
 - Bug #127: Fix `encode` key leaking into HTML attributes in `Breadcrumbs::renderItem()` (@WarLikeLaux)
 - New #129: Add `id()` method to `Menu` and `Breadcrumbs` widgets (@WarLikeLaux)
-- New #117: Add container wrapper and JSON-LD structured data to `Breadcrumbs` widget (@WarLikeLaux, @vjik)
+- New #115: Add container wrapper and JSON-LD structured data to `Breadcrumbs` widget (@WarLikeLaux, @vjik)
 - Bug #118: Add missing ARIA attributes to `Dropdown`, `Menu`, and `Alert` (@WarLikeLaux)
 - Enh #155: Add `url` as alias for `link` in `Menu` and `Dropdown` items (@WarLikeLaux)
 - Enh #157: Improve psalm type annotations (@Tigrov)

--- a/docs/guide/en/breadcrumbs.md
+++ b/docs/guide/en/breadcrumbs.md
@@ -41,6 +41,67 @@ The code above generates the following HTML:
 </ul>
 ```
 
+## Container wrapper
+
+You can wrap the breadcrumbs in a container tag (e.g. `<nav>`) using `container(true)`:
+
+```php
+echo Breadcrumbs::widget()
+    ->container(true)
+    ->containerTag('nav')
+    ->containerAttributes(['aria-label' => 'breadcrumb'])
+    ->items([
+        ['label' => 'Category', 'url' => '/category'],
+        'Current Page',
+    ])
+    ->render();
+```
+
+The code above generates the following HTML:
+
+```html
+<nav aria-label="breadcrumb">
+<ul class="breadcrumb">
+<li><a href="/">Home</a></li>
+<li><a href="/category">Category</a></li>
+<li class="active">Current Page</li>
+</ul>
+</nav>
+```
+
+## JSON-LD structured data
+
+The widget can generate [Schema.org BreadcrumbList](https://schema.org/BreadcrumbList) structured data
+in JSON-LD format. This helps search engines understand the page hierarchy.
+
+```php
+echo Breadcrumbs::widget()
+    ->jsonLd(true)
+    ->items([
+        ['label' => 'Category', 'url' => 'https://example.com/category'],
+        'Current Page',
+    ])
+    ->render();
+```
+
+This appends a `<script type="application/ld+json">` block after the breadcrumbs HTML:
+
+```json
+{
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+        {"@type": "ListItem", "position": 1, "name": "Home", "item": "/"},
+        {"@type": "ListItem", "position": 2, "name": "Category", "item": "https://example.com/category"},
+        {"@type": "ListItem", "position": 3, "name": "Current Page"}
+    ]
+}
+```
+
+JSON-LD is used instead of microdata or RDFa because it lives in a separate `<script>` block and does not
+require modifications to the breadcrumb HTML tags. This avoids conflicts with custom `itemTemplate`
+and `activeItemTemplate`.
+
 ## Setters
 
 All setters are immutable and return a new instance of the `Yiisoft\Yii\Widgets\Breadcrumbs`
@@ -50,7 +111,13 @@ Method | Description | Default
 -------|-------------|---------
 `activeItemTemplate(string $value)`| Template used to render each active item in the breadcrumbs | `"<li class=\"active\">{link}</li>\n"`
 `attributes(array $valuesMap)` | HTML attributes for the breadcrumbs container | `['class' => 'breadcrumb']`
+`container(bool $value)` | Whether to wrap breadcrumbs in a container tag | `false`
+`containerAttributes(array $valuesMap)` | HTML attributes for the container wrapper | `[]`
+`containerClass(string $value)` | CSS class for the container wrapper | `''`
+`containerTag(string $value)` | Tag name for the container wrapper | `'nav'`
 `homeItem(?array $value)` | The first item in the breadcrumbs (called home link) | `['label' => 'Home', 'url' => '/']`
+`id(?string $value)` | The widget ID | `null`
 `items(array $value)` | List of items to appear in the breadcrumbs | `[]`
 `itemTemplate(string $value)` | Template used to render each inactive item in the breadcrumbs | `"<li>{link}</li>\n"`
+`jsonLd(bool $value)` | Whether to render JSON-LD structured data ([BreadcrumbList](https://schema.org/BreadcrumbList)) | `false`
 `tag(string $value)` | The container tag name | `'ul'`

--- a/src/Breadcrumbs.php
+++ b/src/Breadcrumbs.php
@@ -61,6 +61,7 @@ final class Breadcrumbs extends Widget
     private bool $container = false;
     private array $containerAttributes = [];
     private string $containerClass = '';
+    /** @psalm-var non-empty-string */
     private string $containerTag = 'nav';
     private ?array $homeItem = ['label' => 'Home', 'url' => '/'];
     private array $items = [];
@@ -138,12 +139,21 @@ final class Breadcrumbs extends Widget
      * Returns a new instance with the specified container tag.
      *
      * @param string $value The container tag.
+     *
+     * @psalm-param non-empty-string $value
      */
     public function containerTag(string $value): self
     {
+        /**
+         * @psalm-suppress TypeDoesNotContainType This check is necessary to ensure that an empty string is
+         * not accepted, as the type declaration alone cannot enforce non-empty strings.
+         */
+        if ($this->containerTag === '') {
+            throw new InvalidArgumentException('Tag name must be a string and cannot be empty.');
+        }
+
         $new = clone $this;
         $new->containerTag = $value;
-
         return $new;
     }
 
@@ -317,10 +327,6 @@ final class Breadcrumbs extends Widget
             : Html::normalTag($this->tag, PHP_EOL . $body, $this->attributes)->encode(false)->render();
 
         if ($this->container) {
-            if ($this->containerTag === '') {
-                throw new InvalidArgumentException('Tag name must be a string and cannot be empty.');
-            }
-
             $containerAttributes = $this->containerAttributes;
 
             if ($this->containerClass !== '') {

--- a/src/Breadcrumbs.php
+++ b/src/Breadcrumbs.php
@@ -16,7 +16,6 @@ use function json_encode;
 use function strtr;
 
 use const JSON_THROW_ON_ERROR;
-use const JSON_UNESCAPED_SLASHES;
 use const JSON_UNESCAPED_UNICODE;
 use const PHP_EOL;
 
@@ -385,7 +384,7 @@ final class Breadcrumbs extends Widget
             'itemListElement' => $listElements,
         ];
 
-        $json = json_encode($data, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        $json = json_encode($data, JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE);
 
         return '<script type="application/ld+json">' . $json . '</script>';
     }

--- a/src/Breadcrumbs.php
+++ b/src/Breadcrumbs.php
@@ -12,8 +12,12 @@ use function array_key_exists;
 use function implode;
 use function is_array;
 use function is_string;
+use function json_encode;
 use function strtr;
 
+use const JSON_THROW_ON_ERROR;
+use const JSON_UNESCAPED_SLASHES;
+use const JSON_UNESCAPED_UNICODE;
 use const PHP_EOL;
 
 /**
@@ -54,9 +58,14 @@ final class Breadcrumbs extends Widget
 {
     private string $activeItemTemplate = "<li class=\"active\">{link}</li>\n";
     private array $attributes = ['class' => 'breadcrumb'];
+    private bool $container = false;
+    private array $containerAttributes = [];
+    private string $containerClass = '';
+    private string $containerTag = 'nav';
     private ?array $homeItem = ['label' => 'Home', 'url' => '/'];
     private array $items = [];
     private string $itemTemplate = "<li>{link}</li>\n";
+    private bool $jsonLd = false;
     private string $tag = 'ul';
 
     /**
@@ -82,6 +91,58 @@ final class Breadcrumbs extends Widget
     {
         $new = clone $this;
         $new->attributes = $valuesMap;
+
+        return $new;
+    }
+
+    /**
+     * Returns a new instance with the specified if the container is enabled, or not. Default is false.
+     *
+     * @param bool $value The container enabled.
+     */
+    public function container(bool $value): self
+    {
+        $new = clone $this;
+        $new->container = $value;
+
+        return $new;
+    }
+
+    /**
+     * Returns a new instance with the specified container HTML attributes.
+     *
+     * @param array $valuesMap Attribute values indexed by attribute names.
+     */
+    public function containerAttributes(array $valuesMap): self
+    {
+        $new = clone $this;
+        $new->containerAttributes = $valuesMap;
+
+        return $new;
+    }
+
+    /**
+     * Returns a new instance with the specified container class.
+     *
+     * @param string $value The container class.
+     */
+    public function containerClass(string $value): self
+    {
+        $new = clone $this;
+        $new->containerClass = $value;
+
+        return $new;
+    }
+
+    /**
+     * Returns a new instance with the specified container tag.
+     *
+     * @param string $value The container tag.
+     */
+    public function containerTag(string $value): self
+    {
+        $new = clone $this;
+        $new->containerTag = $value;
 
         return $new;
     }
@@ -169,6 +230,22 @@ final class Breadcrumbs extends Widget
     }
 
     /**
+     * Returns a new instance with JSON-LD structured data rendering enabled or disabled.
+     *
+     * When enabled, a `<script type="application/ld+json">` block with BreadcrumbList structured data
+     * is appended to the widget output.
+     *
+     * @param bool $value Whether to render JSON-LD structured data.
+     */
+    public function jsonLd(bool $value): self
+    {
+        $new = clone $this;
+        $new->jsonLd = $value;
+
+        return $new;
+    }
+
+    /**
      * Returns a new instance with the specified tag.
      *
      * @param string $value The tag name.
@@ -213,9 +290,100 @@ final class Breadcrumbs extends Widget
 
         $body = implode('', $items);
 
-        return empty($this->tag)
+        $result = empty($this->tag)
             ? $body
             : Html::normalTag($this->tag, PHP_EOL . $body, $this->attributes)->encode(false)->render();
+
+        if ($this->container) {
+            if ($this->containerTag === '') {
+                throw new InvalidArgumentException('Tag name must be a string and cannot be empty.');
+            }
+
+            $containerAttributes = $this->containerAttributes;
+
+            if ($this->containerClass !== '') {
+                Html::addCssClass($containerAttributes, $this->containerClass);
+            }
+
+            $result = Html::normalTag($this->containerTag, PHP_EOL . $result . PHP_EOL, $containerAttributes)
+                ->encode(false)
+                ->render();
+        }
+
+        if ($this->jsonLd) {
+            $result .= PHP_EOL . $this->renderJsonLd();
+        }
+
+        return $result;
+    }
+
+    /**
+     * Renders JSON-LD structured data for the breadcrumbs.
+     *
+     * @return string The `<script type="application/ld+json">` block with BreadcrumbList structured data.
+     */
+    public function renderJsonLd(): string
+    {
+        $listElements = [];
+        $position = 1;
+
+        if ($this->homeItem !== null) {
+            $element = $this->buildJsonLdItem($this->homeItem, $position);
+            if ($element !== null) {
+                $listElements[] = $element;
+                $position++;
+            }
+        }
+
+        foreach ($this->items as $item) {
+            if (!is_array($item)) {
+                $item = ['label' => $item];
+            }
+
+            if ($item === []) {
+                continue;
+            }
+
+            $element = $this->buildJsonLdItem($item, $position);
+            if ($element !== null) {
+                $listElements[] = $element;
+                $position++;
+            }
+        }
+
+        $data = [
+            '@context' => 'https://schema.org',
+            '@type' => 'BreadcrumbList',
+            'itemListElement' => $listElements,
+        ];
+
+        $json = json_encode($data, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+
+        return '<script type="application/ld+json">' . $json . '</script>';
+    }
+
+    /**
+     * Builds a single JSON-LD ListItem element.
+     *
+     * @return array|null The ListItem data, or null if the item has no label.
+     */
+    private function buildJsonLdItem(array $item, int $position): ?array
+    {
+        if (!isset($item['label']) || !is_string($item['label'])) {
+            return null;
+        }
+
+        $element = [
+            '@type' => 'ListItem',
+            'position' => $position,
+            'name' => $item['label'],
+        ];
+
+        if (isset($item['url']) && is_string($item['url'])) {
+            $element['item'] = $item['url'];
+        }
+
+        return $element;
     }
 
     /**

--- a/src/Breadcrumbs.php
+++ b/src/Breadcrumbs.php
@@ -256,6 +256,8 @@ final class Breadcrumbs extends Widget
      * is appended to the widget output.
      *
      * @param bool $value Whether to render JSON-LD structured data.
+     *
+     * @link https://schema.org/BreadcrumbList
      */
     public function jsonLd(bool $value): self
     {

--- a/src/Breadcrumbs.php
+++ b/src/Breadcrumbs.php
@@ -148,7 +148,7 @@ final class Breadcrumbs extends Widget
          * @psalm-suppress TypeDoesNotContainType This check is necessary to ensure that an empty string is
          * not accepted, as the type declaration alone cannot enforce non-empty strings.
          */
-        if ($this->containerTag === '') {
+        if ($value === '') {
             throw new InvalidArgumentException('Tag name must be a string and cannot be empty.');
         }
 

--- a/src/Breadcrumbs.php
+++ b/src/Breadcrumbs.php
@@ -96,9 +96,9 @@ final class Breadcrumbs extends Widget
     }
 
     /**
-     * Returns a new instance with the specified if the container is enabled, or not. Default is false.
+     * Returns a new instance with whether the container is enabled. Default is false.
      *
-     * @param bool $value The container enabled.
+     * @param bool $value Whether the container is enabled.
      */
     public function container(bool $value): self
     {

--- a/tests/Breadcrumbs/BreadcrumbsTest.php
+++ b/tests/Breadcrumbs/BreadcrumbsTest.php
@@ -310,7 +310,7 @@ final class BreadcrumbsTest extends TestCase
             <li><a href="https://example.com/category">Category</a></li>
             <li class="active">Current Page</li>
             </ul>
-            <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"/"},{"@type":"ListItem","position":2,"name":"Category","item":"https://example.com/category"},{"@type":"ListItem","position":3,"name":"Current Page"}]}</script>
+            <script type="application/ld+json">{"@context":"https:\/\/schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"\/"},{"@type":"ListItem","position":2,"name":"Category","item":"https:\/\/example.com\/category"},{"@type":"ListItem","position":3,"name":"Current Page"}]}</script>
             HTML,
             Breadcrumbs::widget()
                 ->jsonLd(true)
@@ -330,7 +330,7 @@ final class BreadcrumbsTest extends TestCase
             <li><a href="https://example.com/category">Category</a></li>
             <li class="active">Current Page</li>
             </ul>
-            <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Category","item":"https://example.com/category"},{"@type":"ListItem","position":2,"name":"Current Page"}]}</script>
+            <script type="application/ld+json">{"@context":"https:\/\/schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Category","item":"https:\/\/example.com\/category"},{"@type":"ListItem","position":2,"name":"Current Page"}]}</script>
             HTML,
             Breadcrumbs::widget()
                 ->homeItem(null)
@@ -346,7 +346,7 @@ final class BreadcrumbsTest extends TestCase
     public function testRenderJsonLd(): void
     {
         $this->assertSame(
-            '<script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Category","item":"https://example.com/category"},{"@type":"ListItem","position":2,"name":"Current Page"}]}</script>',
+            '<script type="application/ld+json">{"@context":"https:\/\/schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Category","item":"https:\/\/example.com\/category"},{"@type":"ListItem","position":2,"name":"Current Page"}]}</script>',
             Breadcrumbs::widget()
                 ->homeItem(null)
                 ->items([
@@ -360,7 +360,7 @@ final class BreadcrumbsTest extends TestCase
     public function testRenderJsonLdSkipsEmptyItems(): void
     {
         $this->assertSame(
-            '<script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Page"}]}</script>',
+            '<script type="application/ld+json">{"@context":"https:\/\/schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Page"}]}</script>',
             Breadcrumbs::widget()
                 ->homeItem(null)
                 ->items([[], 'Page'])
@@ -371,7 +371,7 @@ final class BreadcrumbsTest extends TestCase
     public function testRenderJsonLdSkipsItemsWithoutLabel(): void
     {
         $this->assertSame(
-            '<script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Page"}]}</script>',
+            '<script type="application/ld+json">{"@context":"https:\/\/schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Page"}]}</script>',
             Breadcrumbs::widget()
                 ->homeItem(null)
                 ->items([['url' => '/no-label'], 'Page'])
@@ -390,7 +390,7 @@ final class BreadcrumbsTest extends TestCase
             <li class="active">Current Page</li>
             </ul>
             </nav>
-            <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"/"},{"@type":"ListItem","position":2,"name":"Category","item":"https://example.com/category"},{"@type":"ListItem","position":3,"name":"Current Page"}]}</script>
+            <script type="application/ld+json">{"@context":"https:\/\/schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"\/"},{"@type":"ListItem","position":2,"name":"Category","item":"https:\/\/example.com\/category"},{"@type":"ListItem","position":3,"name":"Current Page"}]}</script>
             HTML,
             Breadcrumbs::widget()
                 ->container(true)

--- a/tests/Breadcrumbs/BreadcrumbsTest.php
+++ b/tests/Breadcrumbs/BreadcrumbsTest.php
@@ -153,4 +153,196 @@ final class BreadcrumbsTest extends TestCase
                 ->render(),
         );
     }
+
+    public function testContainer(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <nav>
+            <ul class="breadcrumb">
+            <li><a href="/">Home</a></li>
+            <li class="active">Current Page</li>
+            </ul>
+            </nav>
+            HTML,
+            Breadcrumbs::widget()
+                ->container(true)
+                ->items(['Current Page'])
+                ->render(),
+        );
+    }
+
+    public function testContainerDisabled(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <ul class="breadcrumb">
+            <li><a href="/">Home</a></li>
+            <li class="active">Current Page</li>
+            </ul>
+            HTML,
+            Breadcrumbs::widget()
+                ->container(false)
+                ->items(['Current Page'])
+                ->render(),
+        );
+    }
+
+    public function testContainerAttributes(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <nav aria-label="Breadcrumb">
+            <ul class="breadcrumb">
+            <li><a href="/">Home</a></li>
+            <li class="active">Current Page</li>
+            </ul>
+            </nav>
+            HTML,
+            Breadcrumbs::widget()
+                ->container(true)
+                ->containerAttributes(['aria-label' => 'Breadcrumb'])
+                ->items(['Current Page'])
+                ->render(),
+        );
+    }
+
+    public function testContainerClass(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <nav class="breadcrumb-nav">
+            <ul class="breadcrumb">
+            <li><a href="/">Home</a></li>
+            <li class="active">Current Page</li>
+            </ul>
+            </nav>
+            HTML,
+            Breadcrumbs::widget()
+                ->container(true)
+                ->containerClass('breadcrumb-nav')
+                ->items(['Current Page'])
+                ->render(),
+        );
+    }
+
+    public function testContainerClassMergesWithAttributes(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <nav class="base breadcrumb-nav" aria-label="Breadcrumb">
+            <ul class="breadcrumb">
+            <li><a href="/">Home</a></li>
+            <li class="active">Current Page</li>
+            </ul>
+            </nav>
+            HTML,
+            Breadcrumbs::widget()
+                ->container(true)
+                ->containerAttributes(['class' => 'base', 'aria-label' => 'Breadcrumb'])
+                ->containerClass('breadcrumb-nav')
+                ->items(['Current Page'])
+                ->render(),
+        );
+    }
+
+    public function testContainerTag(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <div>
+            <ul class="breadcrumb">
+            <li><a href="/">Home</a></li>
+            <li class="active">Current Page</li>
+            </ul>
+            </div>
+            HTML,
+            Breadcrumbs::widget()
+                ->container(true)
+                ->containerTag('div')
+                ->items(['Current Page'])
+                ->render(),
+        );
+    }
+
+    public function testJsonLd(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <ul class="breadcrumb">
+            <li><a href="/">Home</a></li>
+            <li><a href="https://example.com/category">Category</a></li>
+            <li class="active">Current Page</li>
+            </ul>
+            <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"/"},{"@type":"ListItem","position":2,"name":"Category","item":"https://example.com/category"},{"@type":"ListItem","position":3,"name":"Current Page"}]}</script>
+            HTML,
+            Breadcrumbs::widget()
+                ->jsonLd(true)
+                ->items([
+                    ['label' => 'Category', 'url' => 'https://example.com/category'],
+                    'Current Page',
+                ])
+                ->render(),
+        );
+    }
+
+    public function testJsonLdWithoutHomeItem(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <ul class="breadcrumb">
+            <li><a href="https://example.com/category">Category</a></li>
+            <li class="active">Current Page</li>
+            </ul>
+            <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Category","item":"https://example.com/category"},{"@type":"ListItem","position":2,"name":"Current Page"}]}</script>
+            HTML,
+            Breadcrumbs::widget()
+                ->homeItem(null)
+                ->jsonLd(true)
+                ->items([
+                    ['label' => 'Category', 'url' => 'https://example.com/category'],
+                    'Current Page',
+                ])
+                ->render(),
+        );
+    }
+
+    public function testRenderJsonLd(): void
+    {
+        $this->assertSame(
+            '<script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Category","item":"https://example.com/category"},{"@type":"ListItem","position":2,"name":"Current Page"}]}</script>',
+            Breadcrumbs::widget()
+                ->homeItem(null)
+                ->items([
+                    ['label' => 'Category', 'url' => 'https://example.com/category'],
+                    'Current Page',
+                ])
+                ->renderJsonLd(),
+        );
+    }
+
+    public function testContainerWithJsonLd(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <nav aria-label="Breadcrumb">
+            <ul class="breadcrumb">
+            <li><a href="/">Home</a></li>
+            <li><a href="https://example.com/category">Category</a></li>
+            <li class="active">Current Page</li>
+            </ul>
+            </nav>
+            <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"/"},{"@type":"ListItem","position":2,"name":"Category","item":"https://example.com/category"},{"@type":"ListItem","position":3,"name":"Current Page"}]}</script>
+            HTML,
+            Breadcrumbs::widget()
+                ->container(true)
+                ->containerAttributes(['aria-label' => 'Breadcrumb'])
+                ->jsonLd(true)
+                ->items([
+                    ['label' => 'Category', 'url' => 'https://example.com/category'],
+                    'Current Page',
+                ])
+                ->render(),
+        );
+    }
 }

--- a/tests/Breadcrumbs/BreadcrumbsTest.php
+++ b/tests/Breadcrumbs/BreadcrumbsTest.php
@@ -321,6 +321,28 @@ final class BreadcrumbsTest extends TestCase
         );
     }
 
+    public function testRenderJsonLdSkipsEmptyItems(): void
+    {
+        $this->assertSame(
+            '<script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Page"}]}</script>',
+            Breadcrumbs::widget()
+                ->homeItem(null)
+                ->items([[], 'Page'])
+                ->renderJsonLd(),
+        );
+    }
+
+    public function testRenderJsonLdSkipsItemsWithoutLabel(): void
+    {
+        $this->assertSame(
+            '<script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Page"}]}</script>',
+            Breadcrumbs::widget()
+                ->homeItem(null)
+                ->items([['url' => '/no-label'], 'Page'])
+                ->renderJsonLd(),
+        );
+    }
+
     public function testContainerWithJsonLd(): void
     {
         Assert::equalsWithoutLE(

--- a/tests/Breadcrumbs/ExceptionTest.php
+++ b/tests/Breadcrumbs/ExceptionTest.php
@@ -29,6 +29,13 @@ final class ExceptionTest extends TestCase
         Breadcrumbs::widget()->items([['label' => 1]])->render();
     }
 
+    public function testContainerTag(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Tag name must be a string and cannot be empty.');
+        Breadcrumbs::widget()->container(true)->containerTag('')->items(['test'])->render();
+    }
+
     public function testRenderItem(): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Breadcrumbs/ExceptionTest.php
+++ b/tests/Breadcrumbs/ExceptionTest.php
@@ -31,9 +31,11 @@ final class ExceptionTest extends TestCase
 
     public function testContainerTag(): void
     {
+        $widget = Breadcrumbs::widget();
+
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Tag name must be a string and cannot be empty.');
-        Breadcrumbs::widget()->container(true)->containerTag('')->items(['test'])->render();
+        $widget->containerTag('');
     }
 
     public function testRenderItem(): void

--- a/tests/Breadcrumbs/ImmutableTest.php
+++ b/tests/Breadcrumbs/ImmutableTest.php
@@ -17,9 +17,14 @@ final class ImmutableTest extends TestCase
         $breadcrumbs = Breadcrumbs::widget();
         $this->assertNotSame($breadcrumbs, $breadcrumbs->activeItemTemplate(''));
         $this->assertNotSame($breadcrumbs, $breadcrumbs->attributes([]));
+        $this->assertNotSame($breadcrumbs, $breadcrumbs->container(true));
+        $this->assertNotSame($breadcrumbs, $breadcrumbs->containerAttributes([]));
+        $this->assertNotSame($breadcrumbs, $breadcrumbs->containerClass(''));
+        $this->assertNotSame($breadcrumbs, $breadcrumbs->containerTag('nav'));
         $this->assertNotSame($breadcrumbs, $breadcrumbs->homeItem(null));
         $this->assertNotSame($breadcrumbs, $breadcrumbs->items(['label' => 'value']));
         $this->assertNotSame($breadcrumbs, $breadcrumbs->itemTemplate(''));
+        $this->assertNotSame($breadcrumbs, $breadcrumbs->jsonLd(true));
         $this->assertNotSame($breadcrumbs, $breadcrumbs->tag('ul'));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Tests added?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | #115

## What does this PR do?

Add optional container wrapper and JSON-LD structured data to Breadcrumbs widget.

### Coverage

Tests: 13 → 24. Line coverage: 53/53 (100%) → 111/113 (98%). MSI: 100% (43/43) → 98% (95/96).