### PR TITLE
Add missing ARIA attributes to `Dropdown`, `Menu`, and `Alert`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Enh #108: Bump minimal `yiisoft/html` version to `3.13` and add support for `^4.0` (@vjik)
 - Bug #113: Fix `array_merge()` argument order in `Menu::renderItem()` so that item-level `linkAttributes` override widget-level ones (@WarLikeLaux)
 - Enh #114: Add `readonly` to constructor-promoted properties in `Block`, `ContentDecorator`, and `FragmentCache` (@WarLikeLaux)
+- Bug #118: Add missing ARIA attributes to `Dropdown`, `Menu`, and `Alert` (@WarLikeLaux)
 
 ## 2.1.1 September 23, 2025
 

--- a/src/Alert.php
+++ b/src/Alert.php
@@ -476,7 +476,7 @@ final class Alert extends Widget
     {
         $buttonAttributes = $this->buttonAttributes;
 
-        if (!isset($buttonAttributes['aria-label'])) {
+        if (!array_key_exists('aria-label', $buttonAttributes)) {
             $buttonAttributes['aria-label'] = 'Close';
         }
 

--- a/src/Alert.php
+++ b/src/Alert.php
@@ -474,9 +474,15 @@ final class Alert extends Widget
      */
     private function renderButton(): string
     {
+        $buttonAttributes = $this->buttonAttributes;
+
+        if (!isset($buttonAttributes['aria-label'])) {
+            $buttonAttributes['aria-label'] = 'Close';
+        }
+
         return PHP_EOL
             . (new Button())
-                ->attributes($this->buttonAttributes)
+                ->attributes($buttonAttributes)
                 ->content($this->buttonLabel)
                 ->encode(false)
                 ->type('button')

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -563,11 +563,12 @@ final class Dropdown extends Widget
         }
 
         if ($item['active']) {
-            $linkAttributes['aria-current'] = 'true';
+            $linkAttributes['aria-current'] = 'page';
             Html::addCssClass($linkAttributes, [$this->activeClass]);
         }
 
         if ($item['disabled']) {
+            $linkAttributes['aria-disabled'] = 'true';
             Html::addCssClass($linkAttributes, $this->disabledClass);
         }
 

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -621,6 +621,7 @@ final class Menu extends Widget
         }
 
         if ($item['disabled']) {
+            $linkAttributes['aria-disabled'] = 'true';
             Html::addCssClass($linkAttributes, $this->disabledClass);
         }
 

--- a/tests/Alert/AlertTest.php
+++ b/tests/Alert/AlertTest.php
@@ -19,7 +19,7 @@ final class AlertTest extends TestCase
             <<<HTML
             <div role="alert" id="w0-alert">
             <span class="test-class">This is a test.</span>
-            <button type="button">&times;</button>
+            <button aria-label="Close" type="button">&times;</button>
             </div>
             HTML,
             Alert::widget()
@@ -37,7 +37,7 @@ final class AlertTest extends TestCase
             <div role="alert" id="w0-alert">
             <div class="test-class">
             <span>This is a test.</span>
-            <button type="button">&times;</button>
+            <button aria-label="Close" type="button">&times;</button>
             </div>
             </div>
             HTML,
@@ -56,7 +56,7 @@ final class AlertTest extends TestCase
             <<<HTML
             <div role="alert" id="w0-alert">
             This is a test.
-            <button type="button">&times;</button>
+            <button aria-label="Close" type="button">&times;</button>
             </div>
             HTML,
             Alert::widget()
@@ -73,7 +73,7 @@ final class AlertTest extends TestCase
             <<<HTML
             <div id="alert-1" role="alert">
             <span>This is a test.</span>
-            <button type="button">&times;</button>
+            <button aria-label="Close" type="button">&times;</button>
             </div>
             HTML,
             Alert::widget()->body('This is a test.')->render(),
@@ -87,7 +87,7 @@ final class AlertTest extends TestCase
             <div role="alert" id="w0-alert">
             <span class="tests-class">Header title</span>
             <span>This is a test.</span>
-            <button type="button">&times;</button>
+            <button aria-label="Close" type="button">&times;</button>
             </div>
             HTML,
             Alert::widget()
@@ -109,7 +109,7 @@ final class AlertTest extends TestCase
             <span>Header title</span>
             </div>
             <span>This is a test.</span>
-            <button type="button">&times;</button>
+            <button aria-label="Close" type="button">&times;</button>
             </div>
             HTML,
             Alert::widget()
@@ -167,7 +167,7 @@ final class AlertTest extends TestCase
             <div role="alert" id="w0-alert">
             <span><b>Bold</b></span>
             <span>Body</span>
-            <button type="button">&times;</button>
+            <button aria-label="Close" type="button">&times;</button>
             </div>
             HTML,
             Alert::widget()
@@ -204,7 +204,7 @@ final class AlertTest extends TestCase
             <div role="alert" id="w0-alert">
             <span>H</span>
             <span>Body</span>
-            <button type="button">&times;</button>
+            <button aria-label="Close" type="button">&times;</button>
             </div>
             HTML,
             Alert::widget()

--- a/tests/Alert/BulmaTest.php
+++ b/tests/Alert/BulmaTest.php
@@ -22,7 +22,7 @@ final class BulmaTest extends TestCase
             <<<HTML
             <div role="alert" class="notification is-danger" id="w0-alert">
             <span>An example alert with an icon.</span>
-            <button class="delete" type="button">&times;</button>
+            <button class="delete" aria-label="Close" type="button">&times;</button>
             </div>
             HTML,
             Alert::widget()
@@ -40,7 +40,7 @@ final class BulmaTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div role="alert" class="notification is-danger" id="w0-alert">
-            <button class="delete" type="button">&times;</button>
+            <button class="delete" aria-label="Close" type="button">&times;</button>
             <div class="is-flex is-align-items-center">
             <div><i class="fa-2x fas fa-exclamation-circle mr-4"></i></div>
             <span>An example alert with an icon.</span>

--- a/tests/Alert/TailwindTest.php
+++ b/tests/Alert/TailwindTest.php
@@ -22,7 +22,7 @@ final class TailwindTest extends TestCase
             <<<HTML
             <div role="alert" class="bg-blue-100 border-b border-blue-500 border-t px-4 py-3 text-blue-700" id="w0-alert">
             <span class="align-middle inline-block mr-8"><p class="font-bold">Informational message</p><p class="text-sm">Some additional text to explain said message.</p></span>
-            <button class="float-right px-4 py-3" onclick="closeAlert()" type="button">&times;</button>
+            <button class="float-right px-4 py-3" onclick="closeAlert()" aria-label="Close" type="button">&times;</button>
             </div>
             HTML,
             Alert::widget()
@@ -48,7 +48,7 @@ final class TailwindTest extends TestCase
             <<<HTML
             <div role="alert" class="bg-yellow-100 border-l-2 border-yellow-500 p-4 text-yellow-700" id="w0-alert">
             <span class="align-middle inline-block mr-8"><p><b>Be Warned</b></p> <p>Something not ideal might be happening.</p></span>
-            <button class="absolute bottom-0 px-4 py-3 right-0 top-0" onclick="closeAlert()" type="button">&times;</button>
+            <button class="absolute bottom-0 px-4 py-3 right-0 top-0" onclick="closeAlert()" aria-label="Close" type="button">&times;</button>
             </div>
             HTML,
             Alert::widget()
@@ -70,7 +70,7 @@ final class TailwindTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div role="alert" class="bg-gray-900 lg:px-4 py-4 text-center text-white" id="w0-alert">
-            <button class="bottom-0 px-4 py-3 right-0 top-0" onclick="closeAlert()" type="button">&times;</button>
+            <button class="bottom-0 px-4 py-3 right-0 top-0" onclick="closeAlert()" aria-label="Close" type="button">&times;</button>
             <div class="bg-gray-800 p-2 flex items-center leading-none lg:inline-flex lg:rounded-full">
             <div class="bg-gray-500 flex font-bold ml-2 mr-3 px-2 py-1 rounded-full text-xs uppercase"><i class="not-italic">🔔 New </i></div>
             <span class="flex-auto font-semibold mr-2 text-left">Get the coolest t-shirts from our brand new store</span>
@@ -105,7 +105,7 @@ final class TailwindTest extends TestCase
             <div role="alert" class="bg-blue-500 flex font-bold items-center px-4 py-3 text-sm text-white" id="w0-alert">
             <div><i class="pr-2">i</i></div>
             <p class="align-middle flex-grow inline-block mr-8">Something happened that you should know about.</p>
-            <button class="float-right px-4 py-3" onclick="closeAlert()" type="button">&times;</button>
+            <button class="float-right px-4 py-3" onclick="closeAlert()" aria-label="Close" type="button">&times;</button>
             </div>
             HTML,
             Alert::widget()
@@ -132,7 +132,7 @@ final class TailwindTest extends TestCase
             <<<HTML
             <div role="alert" class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative" id="w0-alert">
             <span class="align-middle inline-block mr-8"><b>Holy smokes!</b> Something seriously bad happened.</span>
-            <button class="absolute bottom-0 px-4 py-3 right-0 top-0" onclick="closeAlert()" type="button">&times;</button>
+            <button class="absolute bottom-0 px-4 py-3 right-0 top-0" onclick="closeAlert()" aria-label="Close" type="button">&times;</button>
             </div>
             HTML,
             Alert::widget()
@@ -159,7 +159,7 @@ final class TailwindTest extends TestCase
             </div>
             <div class="bg-red-100 border border-red-400 border-t-0 rounded-b text-red-700">
             <span class="align-middle inline-block mr-8 px-4 py-3">Something not ideal might be happening.</span>
-            <button class="float-right px-4 py-3" onclick="closeAlert()" type="button">&times;</button>
+            <button class="float-right px-4 py-3" onclick="closeAlert()" aria-label="Close" type="button">&times;</button>
             </div>
             </div>
             HTML,
@@ -191,7 +191,7 @@ final class TailwindTest extends TestCase
             <div class="flex">
             <div class="fill-current h-6 mr-4 py-1 text-green-500 w-6"><i class="not-italic">🛈</i></div>
             <span class="align-middle inline-block flex-grow mr-8"><p class="font-bold">Our privacy policy has changed</p><p class="text-sm">Make sure you know how these changes affect you.</p></span>
-            <button class="float-right px-4 py-3" onclick="closeAlert()" type="button">&times;</button>
+            <button class="float-right px-4 py-3" onclick="closeAlert()" aria-label="Close" type="button">&times;</button>
             </div>
             </div>
             HTML,

--- a/tests/Dropdown/DropdownTest.php
+++ b/tests/Dropdown/DropdownTest.php
@@ -26,11 +26,11 @@ final class DropdownTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div>
-            <li><a aria-current="true" class="test-active-class" href="#">Action</a></li>
+            <li><a aria-current="page" class="test-active-class" href="#">Action</a></li>
             <li><a href="#">Another action</a></li>
             <li><a href="#">Something else here</a></li>
             <li><hr class="dropdown-divider"></li>
-            <li><a class="disabled" href="#">Separated link</a></li>
+            <li><a aria-disabled="true" class="disabled" href="#">Separated link</a></li>
             </div>
             HTML,
             Dropdown::widget()->activeClass('test-active-class')->items($this->items)->render(),
@@ -42,11 +42,11 @@ final class DropdownTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div class="dropdown">
-            <li><a aria-current="true" class="active" href="#">Action</a></li>
+            <li><a aria-current="page" class="active" href="#">Action</a></li>
             <li><a href="#">Another action</a></li>
             <li><a href="#">Something else here</a></li>
             <li><hr class="dropdown-divider"></li>
-            <li><a class="disabled" href="#">Separated link</a></li>
+            <li><a aria-disabled="true" class="disabled" href="#">Separated link</a></li>
             </div>
             HTML,
             Dropdown::widget()->containerAttributes(['class' => 'dropdown'])->items($this->items)->render(),
@@ -58,11 +58,11 @@ final class DropdownTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div class="dropdown">
-            <li><a aria-current="true" class="active" href="#">Action</a></li>
+            <li><a aria-current="page" class="active" href="#">Action</a></li>
             <li><a href="#">Another action</a></li>
             <li><a href="#">Something else here</a></li>
             <li><hr class="dropdown-divider"></li>
-            <li><a class="disabled" href="#">Separated link</a></li>
+            <li><a aria-disabled="true" class="disabled" href="#">Separated link</a></li>
             </div>
             HTML,
             Dropdown::widget()->containerClass('dropdown')->items($this->items)->render(),
@@ -74,11 +74,11 @@ final class DropdownTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <article>
-            <li><a aria-current="true" class="active" href="#">Action</a></li>
+            <li><a aria-current="page" class="active" href="#">Action</a></li>
             <li><a href="#">Another action</a></li>
             <li><a href="#">Something else here</a></li>
             <li><hr class="dropdown-divider"></li>
-            <li><a class="disabled" href="#">Separated link</a></li>
+            <li><a aria-disabled="true" class="disabled" href="#">Separated link</a></li>
             </article>
             HTML,
             Dropdown::widget()->containerTag('article')->items($this->items)->render(),
@@ -90,11 +90,11 @@ final class DropdownTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div>
-            <li><a aria-current="true" class="active" href="#">Action</a></li>
+            <li><a aria-current="page" class="active" href="#">Action</a></li>
             <li><a href="#">Another action</a></li>
             <li><a href="#">Something else here</a></li>
             <li><hr class="dropdown-divider"></li>
-            <li><a class="test-disabled-class" href="#">Separated link</a></li>
+            <li><a aria-disabled="true" class="test-disabled-class" href="#">Separated link</a></li>
             </div>
             HTML,
             Dropdown::widget()->disabledClass('test-disabled-class')->items($this->items)->render(),
@@ -106,11 +106,11 @@ final class DropdownTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div>
-            <li><a aria-current="true" class="active" href="#">Action</a></li>
+            <li><a aria-current="page" class="active" href="#">Action</a></li>
             <li><a href="#">Another action</a></li>
             <li><a href="#">Something else here</a></li>
             <li><span class="dropdown-divider"></span></li>
-            <li><a class="disabled" href="#">Separated link</a></li>
+            <li><a aria-disabled="true" class="disabled" href="#">Separated link</a></li>
             </div>
             HTML,
             Dropdown::widget()->dividerTag('span')->items($this->items)->render(),
@@ -122,11 +122,11 @@ final class DropdownTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div>
-            <a aria-current="true" class="active" href="#">Action</a>
+            <a aria-current="page" class="active" href="#">Action</a>
             <a href="#">Another action</a>
             <a href="#">Something else here</a>
             <li><hr class="dropdown-divider"></li>
-            <a class="disabled" href="#">Separated link</a>
+            <a aria-disabled="true" class="disabled" href="#">Separated link</a>
             </div>
             HTML,
             Dropdown::widget()->itemContainer(false)->items($this->items)->render(),
@@ -138,11 +138,11 @@ final class DropdownTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div>
-            <li class="test-class"><a aria-current="true" class="active" href="#">Action</a></li>
+            <li class="test-class"><a aria-current="page" class="active" href="#">Action</a></li>
             <li class="test-class"><a href="#">Another action</a></li>
             <li class="test-class"><a href="#">Something else here</a></li>
             <li class="test-class"><hr class="dropdown-divider"></li>
-            <li class="test-class"><a class="disabled" href="#">Separated link</a></li>
+            <li class="test-class"><a aria-disabled="true" class="disabled" href="#">Separated link</a></li>
             </div>
             HTML,
             Dropdown::widget()->itemContainerAttributes(['class' => 'test-class'])->items($this->items)->render(),
@@ -151,11 +151,11 @@ final class DropdownTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div>
-            <li class="test-class"><a aria-current="true" class="active" href="#">Action</a></li>
+            <li class="test-class"><a aria-current="page" class="active" href="#">Action</a></li>
             <li class="test-class-2"><a href="#">Another action</a></li>
             <li class="test-class"><a href="#">Something else here</a></li>
             <li class="test-class"><hr class="dropdown-divider"></li>
-            <li class="test-class-5"><a class="disabled" href="#">Separated link</a></li>
+            <li class="test-class-5"><a aria-disabled="true" class="disabled" href="#">Separated link</a></li>
             </div>
             HTML,
             Dropdown::widget()
@@ -186,11 +186,11 @@ final class DropdownTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div>
-            <li class="test-class"><a aria-current="true" class="active" href="#">Action</a></li>
+            <li class="test-class"><a aria-current="page" class="active" href="#">Action</a></li>
             <li class="test-class"><a href="#">Another action</a></li>
             <li class="test-class"><a href="#">Something else here</a></li>
             <li class="test-class"><hr class="dropdown-divider"></li>
-            <li class="test-class"><a class="disabled" href="#">Separated link</a></li>
+            <li class="test-class"><a aria-disabled="true" class="disabled" href="#">Separated link</a></li>
             </div>
             HTML,
             Dropdown::widget()->itemContainerClass('test-class')->items($this->items)->render(),

--- a/tests/Menu/MenuTest.php
+++ b/tests/Menu/MenuTest.php
@@ -164,7 +164,7 @@ final class MenuTest extends TestCase
             <li><a href="/active">Active</a></li>
             <li><a href="#">Much longer nav link</a></li>
             <li><a href="#">Link</a></li>
-            <li><a class="disabled" href="#">Disabled</a></li>
+            <li><a aria-disabled="true" class="disabled" href="#">Disabled</a></li>
             HTML,
             Menu::widget()->container(false)->items($this->itemsWithOptions)->render(),
         );
@@ -178,7 +178,7 @@ final class MenuTest extends TestCase
             <li><a href="/active">Active</a></li>
             <li><a href="#">Much longer nav link</a></li>
             <li><a href="#">Link</a></li>
-            <li><a class="disabled-class" href="#">Disabled</a></li>
+            <li><a aria-disabled="true" class="disabled-class" href="#">Disabled</a></li>
             </ul>
             HTML,
             Menu::widget()->disabledClass('disabled-class')->items($this->itemsWithOptions)->render(),
@@ -202,7 +202,7 @@ final class MenuTest extends TestCase
             </ul>
             </li>
             <li><a href="#">Link</a></li>
-            <li><a class="disabled" href="#">Disabled</a></li>
+            <li><a aria-disabled="true" class="disabled" href="#">Disabled</a></li>
             </ul>
             HTML,
             Menu::widget()
@@ -246,7 +246,7 @@ final class MenuTest extends TestCase
             </ul>
             </li>
             <li><a href="#">Link</a></li>
-            <li><a class="disabled" href="#">Disabled</a></li>
+            <li><a aria-disabled="true" class="disabled" href="#">Disabled</a></li>
             </ul>
             HTML,
             Menu::widget()
@@ -291,7 +291,7 @@ final class MenuTest extends TestCase
             </ul>
             </li>
             <li><a href="#">Link</a></li>
-            <li><a class="disabled" href="#">Disabled</a></li>
+            <li><a aria-disabled="true" class="disabled" href="#">Disabled</a></li>
             </ul>
             HTML,
             Menu::widget()
@@ -344,7 +344,7 @@ final class MenuTest extends TestCase
             <li class="first-item-class"><a href="/active">Active</a></li>
             <li><a href="#">Much longer nav link</a></li>
             <li><a href="#">Link</a></li>
-            <li><a class="disabled" href="#">Disabled</a></li>
+            <li><a aria-disabled="true" class="disabled" href="#">Disabled</a></li>
             </ul>
             HTML,
             Menu::widget()->firstItemClass('first-item-class')->items($this->itemsWithOptions)->render(),
@@ -403,7 +403,7 @@ final class MenuTest extends TestCase
             <li class="nav-item"><a href="/active">Active</a></li>
             <li class="nav-item"><a href="#">Much longer nav link</a></li>
             <li class="nav-item"><a href="#">Link</a></li>
-            <li class="nav-item"><a class="disabled" href="#">Disabled</a></li>
+            <li class="nav-item"><a aria-disabled="true" class="disabled" href="#">Disabled</a></li>
             </ul>
             HTML,
             Menu::widget()->itemsContainerAttributes(['class' => 'nav-item'])->items($this->itemsWithOptions)->render(),
@@ -418,7 +418,7 @@ final class MenuTest extends TestCase
             <li class="nav-item"><a href="/active">Active</a></li>
             <li class="nav-item"><a href="#">Much longer nav link</a></li>
             <li class="nav-item"><a href="#">Link</a></li>
-            <li class="nav-item"><a class="disabled" href="#">Disabled</a></li>
+            <li class="nav-item"><a aria-disabled="true" class="disabled" href="#">Disabled</a></li>
             </ul>
             HTML,
             Menu::widget()->itemsContainerClass('nav-item')->items($this->itemsWithOptions)->render(),
@@ -433,7 +433,7 @@ final class MenuTest extends TestCase
             <a href="/active">Active</a>
             <a href="#">Much longer nav link</a>
             <a href="#">Link</a>
-            <a class="disabled" href="#">Disabled</a>
+            <a aria-disabled="true" class="disabled" href="#">Disabled</a>
             </ul>
             HTML,
             Menu::widget()->itemsContainer(false)->items($this->itemsWithOptions)->render(),
@@ -597,7 +597,7 @@ final class MenuTest extends TestCase
             <li><a href="/active">Active</a></li>
             <li><a href="#">Much longer nav link</a></li>
             <li><a href="#">Link</a></li>
-            <li class="last-item-class"><a class="disabled" href="#">Disabled</a></li>
+            <li class="last-item-class"><a aria-disabled="true" class="disabled" href="#">Disabled</a></li>
             </ul>
             HTML,
             Menu::widget()->lastItemClass('last-item-class')->items($this->itemsWithOptions)->render(),
@@ -612,7 +612,7 @@ final class MenuTest extends TestCase
             <li><a class="test-class" href="/active">Active</a></li>
             <li><a class="test-class" href="#">Much longer nav link</a></li>
             <li><a class="test-class" href="#">Link</a></li>
-            <li><a class="test-class disabled" href="#">Disabled</a></li>
+            <li><a aria-disabled="true" class="test-class disabled" href="#">Disabled</a></li>
             </ul>
             HTML,
             Menu::widget()->linkClass('test-class')->items($this->itemsWithOptions)->render(),
@@ -632,7 +632,7 @@ final class MenuTest extends TestCase
             <div class="test-class"><li><a href="/active">Active</a></li></div>
             <div class="test-class"><li><a href="#">Much longer nav link</a></li></div>
             <div class="test-class"><li><a href="#">Link</a></li></div>
-            <div class="test-class"><li><a class="disabled" href="#">Disabled</a></li></div>
+            <div class="test-class"><li><a aria-disabled="true" class="disabled" href="#">Disabled</a></li></div>
             </ul>
             HTML,
             Menu::widget()->items($this->itemsWithOptions)->template('<div class="test-class">{items}</div>')->render(),

--- a/tests/Menu/MenuTest.php
+++ b/tests/Menu/MenuTest.php
@@ -612,7 +612,7 @@ final class MenuTest extends TestCase
             <li><a class="test-class" href="/active">Active</a></li>
             <li><a class="test-class" href="#">Much longer nav link</a></li>
             <li><a class="test-class" href="#">Link</a></li>
-            <li><a aria-disabled="true" class="test-class disabled" href="#">Disabled</a></li>
+            <li><a class="test-class disabled" aria-disabled="true" href="#">Disabled</a></li>
             </ul>
             HTML,
             Menu::widget()->linkClass('test-class')->items($this->itemsWithOptions)->render(),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Tests added?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  |

## What does this PR do?

Add missing ARIA attributes: `aria-disabled` for disabled items in `Dropdown` and `Menu`, `aria-current="page"` instead of `"true"` in `Dropdown`, and default `aria-label="Close"` on `Alert` close button.
