### PR TITLE
Add widget-level `iconContainerAttributes()` to `Dropdown`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,6 @@
 - Chg #105: Raise the minimum PHP version to `8.1` (@rustamwin)
 - Chg #105: Change PHP constraint in `composer.json` to `8.1 - 8.5` (@rustamwin)
 - Enh #108: Bump minimal `yiisoft/html` version to `3.13` and add support for `^4.0` (@vjik)
-- Bug #113: Fix `array_merge()` argument order in `Menu::renderItem()` so that item-level `linkAttributes` override widget-level ones (@WarLikeLaux)
-- Enh #114: Add `readonly` to constructor-promoted properties in `Block`, `ContentDecorator`, and `FragmentCache` (@WarLikeLaux)
-- Bug #118: Add missing ARIA attributes to `Dropdown`, `Menu`, and `Alert` (@WarLikeLaux)
 - Bug #119: Add missing widget-level `iconContainerAttributes()` to `Dropdown` (@WarLikeLaux)
 
 ## 2.1.1 September 23, 2025

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 - Chg #105: Raise the minimum PHP version to `8.1` (@rustamwin)
 - Chg #105: Change PHP constraint in `composer.json` to `8.1 - 8.5` (@rustamwin)
 - Enh #108: Bump minimal `yiisoft/html` version to `3.13` and add support for `^4.0` (@vjik)
+- Bug #113: Fix `array_merge()` argument order in `Menu::renderItem()` so that item-level `linkAttributes` override widget-level ones (@WarLikeLaux)
+- Enh #114: Add `readonly` to constructor-promoted properties in `Block`, `ContentDecorator`, and `FragmentCache` (@WarLikeLaux)
+- Bug #118: Add missing ARIA attributes to `Dropdown`, `Menu`, and `Alert` (@WarLikeLaux)
+- Bug #119: Add missing widget-level `iconContainerAttributes()` to `Dropdown` (@WarLikeLaux)
 
 ## 2.1.1 September 23, 2025
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Enh #155: Add `url` as alias for `link` in `Menu` and `Dropdown` items (@WarLikeLaux)
 - Enh #157: Improve psalm type annotations (@Tigrov)
 - Bug #119: Add missing widget-level `iconContainerAttributes()` to `Dropdown` (@WarLikeLaux)
+- Bug #119: Fix icons double-encoded in nested `Dropdown` items (@WarLikeLaux)
 
 ## 2.1.1 September 23, 2025
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 - Bug #118: Add missing ARIA attributes to `Dropdown`, `Menu`, and `Alert` (@WarLikeLaux)
 - Enh #155: Add `url` as alias for `link` in `Menu` and `Dropdown` items (@WarLikeLaux)
 - Enh #157: Improve psalm type annotations (@Tigrov)
-- Bug #119: Add missing widget-level `iconContainerAttributes()` to `Dropdown` (@WarLikeLaux)
+- New #119: Add `iconContainerAttributes()` method to `Dropdown` widget (@WarLikeLaux)
 - Bug #159: Fix double-encoding of toggle and nested item labels in `Dropdown` (@WarLikeLaux)
 
 ## 2.1.1 September 23, 2025

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,6 @@
 - Enh #155: Add `url` as alias for `link` in `Menu` and `Dropdown` items (@WarLikeLaux)
 - Enh #157: Improve psalm type annotations (@Tigrov)
 - Bug #119: Add missing widget-level `iconContainerAttributes()` to `Dropdown` (@WarLikeLaux)
-- Bug #119: Fix icons double-encoded in nested `Dropdown` items (@WarLikeLaux)
 
 ## 2.1.1 September 23, 2025
 

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -36,6 +36,7 @@ final class Dropdown extends Widget
     private string $dividerTag = 'hr';
     private string $headerClass = '';
     private string $headerTag = 'span';
+    private array $iconContainerAttributes = [];
     private string $id = '';
     private string $itemClass = '';
     private string $itemTag = 'a';
@@ -188,6 +189,19 @@ final class Dropdown extends Widget
     {
         $new = clone $this;
         $new->headerTag = $value;
+
+        return $new;
+    }
+
+    /**
+     * Returns a new instance with the specified icon container HTML attributes.
+     *
+     * @param array $valuesMap Attribute values indexed by attribute names.
+     */
+    public function iconContainerAttributes(array $valuesMap): self
+    {
+        $new = clone $this;
+        $new->iconContainerAttributes = $valuesMap;
 
         return $new;
     }
@@ -453,7 +467,7 @@ final class Dropdown extends Widget
          *   }|string
          * > $normalizedItems
          */
-        $normalizedItems = Helper\Normalizer::dropdown($this->items);
+        $normalizedItems = Helper\Normalizer::dropdown($this->items, $this->iconContainerAttributes);
 
         $containerAttributes = $this->containerAttributes;
 
@@ -504,6 +518,7 @@ final class Dropdown extends Widget
             ->dividerAttributes($this->dividerAttributes)
             ->headerClass($this->headerClass)
             ->headerTag($this->headerTag)
+            ->iconContainerAttributes($this->iconContainerAttributes)
             ->itemClass($this->itemClass)
             ->itemContainerAttributes($this->itemContainerAttributes)
             ->itemContainerTag($this->itemContainerTag)

--- a/src/Helper/Normalizer.php
+++ b/src/Helper/Normalizer.php
@@ -19,7 +19,7 @@ final class Normalizer
     /**
      * Normalize the given array of items for the dropdown.
      */
-    public static function dropdown(array $items): array
+    public static function dropdown(array $items, array $iconContainerAttributes = []): array
     {
         /**
          * @psalm-var array[] $items
@@ -32,7 +32,7 @@ final class Normalizer
                     self::icon($child),
                     self::iconAttributes($child),
                     self::iconClass($child),
-                    self::iconContainerAttributes($child),
+                    self::iconContainerAttributes($child, $iconContainerAttributes),
                 );
                 $items[$i]['active'] = self::active($child, '', '', false);
                 $items[$i]['disabled'] = self::disabled($child);
@@ -45,7 +45,7 @@ final class Normalizer
                 $items[$i]['visible'] = self::visible($child);
 
                 if (isset($child['items']) && is_array($child['items'])) {
-                    $items[$i]['items'] = self::dropdown($child['items']);
+                    $items[$i]['items'] = self::dropdown($child['items'], $iconContainerAttributes);
                 } else {
                     $items[$i]['items'] = [];
                 }

--- a/src/Helper/Normalizer.php
+++ b/src/Helper/Normalizer.php
@@ -54,7 +54,7 @@ final class Normalizer
                 $items[$i]['visible'] = self::visible($child);
 
                 if (isset($child['items']) && is_array($child['items'])) {
-                    $items[$i]['items'] = self::dropdown($child['items'], $iconContainerAttributes);
+                    $items[$i]['items'] = $child['items'];
                 } else {
                     $items[$i]['items'] = [];
                 }

--- a/src/Helper/Normalizer.php
+++ b/src/Helper/Normalizer.php
@@ -54,7 +54,7 @@ final class Normalizer
                 $items[$i]['visible'] = self::visible($child);
 
                 if (isset($child['items']) && is_array($child['items'])) {
-                    $items[$i]['items'] = $child['items'];
+                    $items[$i]['items'] = self::dropdown($child['items']);
                 } else {
                     $items[$i]['items'] = [];
                 }

--- a/src/Helper/Normalizer.php
+++ b/src/Helper/Normalizer.php
@@ -54,7 +54,7 @@ final class Normalizer
                 $items[$i]['visible'] = self::visible($child);
 
                 if (isset($child['items']) && is_array($child['items'])) {
-                    $items[$i]['items'] = self::dropdown($child['items']);
+                    $items[$i]['items'] = self::dropdown($child['items'], $iconContainerAttributes);
                 } else {
                     $items[$i]['items'] = [];
                 }

--- a/tests/Dropdown/DropdownTest.php
+++ b/tests/Dropdown/DropdownTest.php
@@ -384,12 +384,13 @@ final class DropdownTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div>
-            <li><a href="/active"><span><i class="bi bi-house"></i></span>Home</a></li>
-            <li><a href="#"><span><i class="bi bi-envelope"></i></span>Contact</a></li>
+            <li><a href="/active"><span class="me-2"><i class="bi bi-house"></i></span>Home</a></li>
+            <li><a href="#"><span class="me-2"><i class="bi bi-envelope"></i></span>Contact</a></li>
             <li><a href="#"><span class="test-class-1"><i class="bi bi-lock"></i></span>Login</a></li>
             </div>
             HTML,
             Dropdown::widget()
+                ->iconContainerAttributes(['class' => 'me-2'])
                 ->items([
                     ['label' => 'Home', 'link' => '/active', 'iconClass' => 'bi bi-house'],
                     ['label' => 'Contact', 'link' => '#', 'iconClass' => 'bi bi-envelope'],

--- a/tests/Dropdown/DropdownTest.php
+++ b/tests/Dropdown/DropdownTest.php
@@ -308,6 +308,32 @@ final class DropdownTest extends TestCase
         );
     }
 
+    public function testItemsIconContainerAttributesAppliedToSubItems(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <div>
+            <button type="button">Parent</button>
+            <ul>
+            <li><a href="#"><span class="me-2"><i class="bi bi-house"></i></span>Child</a></li>
+            </ul>
+            </div>
+            HTML,
+            Dropdown::widget()
+                ->iconContainerAttributes(['class' => 'me-2'])
+                ->items([
+                    [
+                        'label' => 'Parent',
+                        'link' => '#',
+                        'items' => [
+                            ['label' => 'Child', 'link' => '#', 'iconClass' => 'bi bi-house'],
+                        ],
+                    ],
+                ])
+                ->render(),
+        );
+    }
+
     public function testItemsIconWithEmptyStringLabel(): void
     {
         Assert::equalsWithoutLE(

--- a/tests/Dropdown/DropdownTest.php
+++ b/tests/Dropdown/DropdownTest.php
@@ -328,6 +328,31 @@ final class DropdownTest extends TestCase
         );
     }
 
+    public function testSubDropdownItemIconIsNotDoubleEncoded(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <div>
+            <button type="button">Parent</button>
+            <ul>
+            <li><a href="#"><span><i class="bi bi-house">house</i></span>Child</a></li>
+            </ul>
+            </div>
+            HTML,
+            Dropdown::widget()
+                ->items([
+                    [
+                        'label' => 'Parent',
+                        'link' => '#',
+                        'items' => [
+                            ['label' => 'Child', 'link' => '#', 'icon' => 'house', 'iconClass' => 'bi bi-house'],
+                        ],
+                    ],
+                ])
+                ->render(),
+        );
+    }
+
     public function testItemsLinkAttributes(): void
     {
         Assert::equalsWithoutLE(

--- a/tests/Dropdown/DropdownTest.php
+++ b/tests/Dropdown/DropdownTest.php
@@ -328,31 +328,6 @@ final class DropdownTest extends TestCase
         );
     }
 
-    public function testSubDropdownItemIconIsNotDoubleEncoded(): void
-    {
-        Assert::equalsWithoutLE(
-            <<<HTML
-            <div>
-            <button type="button">Parent</button>
-            <ul>
-            <li><a href="#"><span><i class="bi bi-house">house</i></span>Child</a></li>
-            </ul>
-            </div>
-            HTML,
-            Dropdown::widget()
-                ->items([
-                    [
-                        'label' => 'Parent',
-                        'link' => '#',
-                        'items' => [
-                            ['label' => 'Child', 'link' => '#', 'icon' => 'house', 'iconClass' => 'bi bi-house'],
-                        ],
-                    ],
-                ])
-                ->render(),
-        );
-    }
-
     public function testItemsLinkAttributes(): void
     {
         Assert::equalsWithoutLE(

--- a/tests/Dropdown/ImmutableTest.php
+++ b/tests/Dropdown/ImmutableTest.php
@@ -39,6 +39,7 @@ final class ImmutableTest extends TestCase
         $this->assertNotSame($dropdown, $dropdown->dividerTag(''));
         $this->assertNotSame($dropdown, $dropdown->headerClass(''));
         $this->assertNotSame($dropdown, $dropdown->headerTag(''));
+        $this->assertNotSame($dropdown, $dropdown->iconContainerAttributes([]));
         $this->assertNotSame($dropdown, $dropdown->id(''));
         $this->assertNotSame($dropdown, $dropdown->itemClass(''));
         $this->assertNotSame($dropdown, $dropdown->itemContainer(false));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Tests added?  | ✔️
| Breaks BC?    | ❌

## What does this PR do?

`Menu` already supports widget-level `iconContainerAttributes()`, but `Dropdown` doesn't - `Normalizer::dropdown()` never passes the fallback down to `self::iconContainerAttributes()`, so you can only set icon container attributes per item. This adds the same widget-level setter to `Dropdown` and propagates it into sub-dropdowns.

No BC break: new method with a default parameter value, existing code is unaffected.