### PR TITLE
Add alert button enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 - Enh #108: Bump minimal `yiisoft/html` version to `3.13` and add support for `^4.0` (@vjik)
 - Bug #113: Fix `array_merge()` argument order in `Menu::renderItem()` so that item-level `linkAttributes` override widget-level ones (@WarLikeLaux)
 - Enh #114: Add `readonly` to constructor-promoted properties in `Block`, `ContentDecorator`, and `FragmentCache` (@WarLikeLaux)
+- Bug #119: Add missing widget-level `iconContainerAttributes()` to `Dropdown` (@WarLikeLaux)
+- New #121: Add `buttonEnabled()` method to `Alert` to allow disabling the close button (@WarLikeLaux)
 
 ## 2.1.1 September 23, 2025
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@
 - Enh #108: Bump minimal `yiisoft/html` version to `3.13` and add support for `^4.0` (@vjik)
 - Bug #113: Fix `array_merge()` argument order in `Menu::renderItem()` so that item-level `linkAttributes` override widget-level ones (@WarLikeLaux)
 - Enh #114: Add `readonly` to constructor-promoted properties in `Block`, `ContentDecorator`, and `FragmentCache` (@WarLikeLaux)
-- Bug #119: Add missing widget-level `iconContainerAttributes()` to `Dropdown` (@WarLikeLaux)
 - New #121: Add `buttonEnabled()` method to `Alert` to allow disabling the close button (@WarLikeLaux)
 
 ## 2.1.1 September 23, 2025

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@
 - Bug #113: Fix `array_merge()` argument order in `Menu::renderItem()` so that item-level `linkAttributes` override widget-level ones (@WarLikeLaux)
 - Enh #114: Add `readonly` to constructor-promoted properties in `Block`, `ContentDecorator`, and `FragmentCache` (@WarLikeLaux)
 - Enh #123: Remove redundant `array_merge()` call with single argument in `Dropdown` (@WarLikeLaux)
-- New #121: Add `buttonEnabled()` method to `Alert` to allow disabling the close button (@WarLikeLaux)
 - Enh #132: Remove raw keys from normalized items in `Normalizer::dropdown()` and `Normalizer::menu()` (@WarLikeLaux)
 - Bug #133: Fix `Alert::render()` returning empty string when body is empty but header is set (@WarLikeLaux)
 - New #126: Add `Menu::dropdownContainerAttributes()` method (@WarLikeLaux)
@@ -20,6 +19,7 @@
 - Bug #118: Add missing ARIA attributes to `Dropdown`, `Menu`, and `Alert` (@WarLikeLaux)
 - Enh #155: Add `url` as alias for `link` in `Menu` and `Dropdown` items (@WarLikeLaux)
 - Enh #157: Improve psalm type annotations (@Tigrov)
+- New #121: Add `buttonEnabled()` method to `Alert` to allow disabling the close button (@WarLikeLaux)
 
 ## 2.1.1 September 23, 2025
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 - Bug #118: Add missing ARIA attributes to `Dropdown`, `Menu`, and `Alert` (@WarLikeLaux)
 - Enh #155: Add `url` as alias for `link` in `Menu` and `Dropdown` items (@WarLikeLaux)
 - Enh #157: Improve psalm type annotations (@Tigrov)
-- New #121: Add `buttonEnabled()` method to `Alert` to allow disabling the close button (@WarLikeLaux)
+- New #121: Add `hideButton()` method to `Alert` to allow hiding the close button (@WarLikeLaux)
 - Bug #159: Fix double-encoding of toggle and nested item labels in `Dropdown` (@WarLikeLaux)
 
 ## 2.1.1 September 23, 2025

--- a/src/Alert.php
+++ b/src/Alert.php
@@ -28,6 +28,7 @@ final class Alert extends Widget
 {
     private array $attributes = [];
     private array $buttonAttributes = [];
+    private bool $buttonEnabled = true;
     private string $buttonLabel = '&times;';
     private string $body = '';
     private array $bodyAttributes = [];
@@ -189,6 +190,19 @@ final class Alert extends Widget
     {
         $new = clone $this;
         Html::addCssClass($new->buttonAttributes, $value);
+
+        return $new;
+    }
+
+    /**
+     * Returns a new instance with the button enabled or disabled.
+     *
+     * @param bool $value Whether the close button is enabled.
+     */
+    public function buttonEnabled(bool $value): self
+    {
+        $new = clone $this;
+        $new->buttonEnabled = $value;
 
         return $new;
     }
@@ -474,6 +488,10 @@ final class Alert extends Widget
      */
     private function renderButton(): string
     {
+        if (!$this->buttonEnabled) {
+            return '';
+        }
+
         return PHP_EOL
             . (new Button())
                 ->attributes($this->buttonAttributes)

--- a/src/Alert.php
+++ b/src/Alert.php
@@ -28,7 +28,7 @@ final class Alert extends Widget
 {
     private array $attributes = [];
     private array $buttonAttributes = [];
-    private bool $buttonEnabled = true;
+    private bool $buttonHidden = false;
     private string $buttonLabel = '&times;';
     private string $body = '';
     private array $bodyAttributes = [];
@@ -165,7 +165,7 @@ final class Alert extends Widget
      *
      * The button is displayed in the alert. Clicking on the button will dismiss the alert.
      *
-     * If {@see buttonEnabled} is `false`, no button will be rendered.
+     * If the button is hidden, no button will be rendered.
      *
      * The rest of the options will be rendered as the HTML attributes of the button tag.
      *
@@ -190,19 +190,6 @@ final class Alert extends Widget
     {
         $new = clone $this;
         Html::addCssClass($new->buttonAttributes, $value);
-
-        return $new;
-    }
-
-    /**
-     * Returns a new instance with the button enabled or disabled.
-     *
-     * @param bool $value Whether the close button is enabled.
-     */
-    public function buttonEnabled(bool $value): self
-    {
-        $new = clone $this;
-        $new->buttonEnabled = $value;
 
         return $new;
     }
@@ -283,6 +270,19 @@ final class Alert extends Widget
     {
         $new = clone $this;
         Html::addCssClass($new->headerAttributes, $value);
+
+        return $new;
+    }
+
+    /**
+     * Returns a new instance with the close button hidden or visible.
+     *
+     * @param bool $value Whether to hide the close button.
+     */
+    public function hideButton(bool $value = true): self
+    {
+        $new = clone $this;
+        $new->buttonHidden = $value;
 
         return $new;
     }
@@ -490,7 +490,7 @@ final class Alert extends Widget
      */
     private function renderButton(): string
     {
-        if (!$this->buttonEnabled) {
+        if ($this->buttonHidden) {
             return '';
         }
 

--- a/tests/Alert/AlertTest.php
+++ b/tests/Alert/AlertTest.php
@@ -13,6 +13,22 @@ final class AlertTest extends TestCase
 {
     use TestTrait;
 
+    public function testButtonDisabled(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <div role="alert" id="w0-alert">
+            <span>This is a test.</span>
+            </div>
+            HTML,
+            Alert::widget()
+                ->body('This is a test.')
+                ->buttonEnabled(false)
+                ->id('w0-alert')
+                ->render(),
+        );
+    }
+
     public function testBodyAttributes(): void
     {
         Assert::equalsWithoutLE(

--- a/tests/Alert/AlertTest.php
+++ b/tests/Alert/AlertTest.php
@@ -13,7 +13,7 @@ final class AlertTest extends TestCase
 {
     use TestTrait;
 
-    public function testButtonDisabled(): void
+    public function testHideButton(): void
     {
         Assert::equalsWithoutLE(
             <<<HTML
@@ -23,7 +23,21 @@ final class AlertTest extends TestCase
             HTML,
             Alert::widget()
                 ->body('This is a test.')
-                ->buttonEnabled(false)
+                ->hideButton()
+                ->id('w0-alert')
+                ->render(),
+        );
+
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <div role="alert" id="w0-alert">
+            <span>This is a test.</span>
+            <button aria-label="Close" type="button">&times;</button>
+            </div>
+            HTML,
+            Alert::widget()
+                ->body('This is a test.')
+                ->hideButton(false)
                 ->id('w0-alert')
                 ->render(),
         );

--- a/tests/Alert/ImmutableTest.php
+++ b/tests/Alert/ImmutableTest.php
@@ -25,6 +25,7 @@ final class ImmutableTest extends TestCase
         $this->assertNotSame($alert, $alert->bodyContainer(false));
         $this->assertNotSame($alert, $alert->buttonAttributes([]));
         $this->assertNotSame($alert, $alert->buttonClass(''));
+        $this->assertNotSame($alert, $alert->buttonEnabled(false));
         $this->assertNotSame($alert, $alert->buttonLabel());
         $this->assertNotSame($alert, $alert->buttonOnClick(''));
         $this->assertNotSame($alert, $alert->class(''));

--- a/tests/Alert/ImmutableTest.php
+++ b/tests/Alert/ImmutableTest.php
@@ -25,7 +25,6 @@ final class ImmutableTest extends TestCase
         $this->assertNotSame($alert, $alert->bodyContainer(false));
         $this->assertNotSame($alert, $alert->buttonAttributes([]));
         $this->assertNotSame($alert, $alert->buttonClass(''));
-        $this->assertNotSame($alert, $alert->buttonEnabled(false));
         $this->assertNotSame($alert, $alert->buttonLabel());
         $this->assertNotSame($alert, $alert->buttonOnClick(''));
         $this->assertNotSame($alert, $alert->class(''));
@@ -37,6 +36,7 @@ final class ImmutableTest extends TestCase
         $this->assertNotSame($alert, $alert->headerContainerAttributes([]));
         $this->assertNotSame($alert, $alert->headerContainerClass(''));
         $this->assertNotSame($alert, $alert->headerTag('div'));
+        $this->assertNotSame($alert, $alert->hideButton());
         $this->assertNotSame($alert, $alert->iconAttributes([]));
         $this->assertNotSame($alert, $alert->iconClass(''));
         $this->assertNotSame($alert, $alert->iconContainerAttributes([]));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Docs added?   | ❌
| Tests added?  | ✔️
| Breaks BC?    | ❌

## What does this PR do?

Adds `hideButton()` to `Alert` so the close button can be hidden without a `layoutBody()` workaround.

Use case:

```php
Alert::widget()
    ->body('Saved.')
    ->hideButton()
    ->render();
```

No BC break: this adds a new optional method and leaves the default alert output unchanged.
