### PR TITLE
Validate `ob_get_clean()` result in `ContentDecorator::render()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Enh #108: Bump minimal `yiisoft/html` version to `3.13` and add support for `^4.0` (@vjik)
 - Bug #113: Fix `array_merge()` argument order in `Menu::renderItem()` so that item-level `linkAttributes` override widget-level ones (@WarLikeLaux)
 - Enh #114: Add `readonly` to constructor-promoted properties in `Block`, `ContentDecorator`, and `FragmentCache` (@WarLikeLaux)
+- Bug #122: Validate `ob_get_clean()` result in `ContentDecorator::render()` (@WarLikeLaux)
 
 ## 2.1.1 September 23, 2025
 

--- a/src/ContentDecorator.php
+++ b/src/ContentDecorator.php
@@ -87,8 +87,14 @@ final class ContentDecorator extends Widget
      */
     public function render(): string
     {
+        $content = ob_get_clean();
+
+        if ($content === false || $content === '') {
+            return '';
+        }
+
         $parameters = $this->parameters;
-        $parameters['content'] = ob_get_clean();
+        $parameters['content'] = $content;
 
         /** render under the existing context */
         return $this->webView->render($this->viewFile, $parameters);

--- a/tests/ContentDecorator/ContentDecoratorTest.php
+++ b/tests/ContentDecorator/ContentDecoratorTest.php
@@ -13,6 +13,14 @@ final class ContentDecoratorTest extends TestCase
 {
     use TestTrait;
 
+    public function testEmptyContent(): void
+    {
+        ContentDecorator::widget()->viewFile('@public/view/layout.php')->begin();
+        $result = ContentDecorator::end();
+
+        $this->assertSame('', $result);
+    }
+
     /**
      * @link https://github.com/yiisoft/yii2/issues/15536
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Docs added?   | ❌
| Tests added?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  |

## What does this PR do?

`ContentDecorator::render()` passes `ob_get_clean()` result directly to the view without checking for `false` or empty string, unlike `Block` and `FragmentCache` which both validate the result. This adds the same validation.

No BC break: existing behavior for non-empty content is unchanged, only `false` and empty string are now handled.

### Coverage

3 tests. Line coverage: 15/15 (100%).
