### PR TITLE
Fix #126: Add `Menu::dropdownContainerAttributes()` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Enh #108: Bump minimal `yiisoft/html` version to `3.13` and add support for `^4.0` (@vjik)
 - Bug #113: Fix `array_merge()` argument order in `Menu::renderItem()` so that item-level `linkAttributes` override widget-level ones (@WarLikeLaux)
 - Enh #114: Add `readonly` to constructor-promoted properties in `Block`, `ContentDecorator`, and `FragmentCache` (@WarLikeLaux)
+- New #126: Add `Menu::dropdownContainerAttributes()` method (@WarLikeLaux)
 
 ## 2.1.1 September 23, 2025
 

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -270,6 +270,19 @@ final class Menu extends Widget
     }
 
     /**
+     * Returns a new instance with the specified dropdown container attributes.
+     *
+     * @param array $valuesMap Attribute values indexed by attribute names.
+     */
+    public function dropdownContainerAttributes(array $valuesMap): self
+    {
+        $new = clone $this;
+        $new->dropdownContainerAttributes = $valuesMap;
+
+        return $new;
+    }
+
+    /**
      * Returns a new instance with the specified dropdown container class.
      *
      * @param string $value The dropdown container class.

--- a/tests/Menu/ImmutableTest.php
+++ b/tests/Menu/ImmutableTest.php
@@ -30,6 +30,7 @@ final class ImmutableTest extends TestCase
         $this->assertNotSame($menu, $menu->container(false));
         $this->assertNotSame($menu, $menu->currentPath(''));
         $this->assertNotSame($menu, $menu->disabledClass(''));
+        $this->assertNotSame($menu, $menu->dropdownContainerAttributes([]));
         $this->assertNotSame($menu, $menu->dropdownContainerClass(''));
         $this->assertNotSame($menu, $menu->dropdownContainerTag('div'));
         $this->assertNotSame($menu, $menu->dropdownDefinitions([]));

--- a/tests/Menu/MenuTest.php
+++ b/tests/Menu/MenuTest.php
@@ -229,6 +229,39 @@ final class MenuTest extends TestCase
         );
     }
 
+    public function testDropdownContainerAttributes(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <ul>
+            <li><a aria-current="page" class="active" href="/active">Active</a></li>
+            <li data-test="value">
+            <a aria-expanded="false" data-bs-toggle="dropdown" role="button" href="#">Dropdown</a>
+            <ul>
+            <li><a href="#">Action</a></li>
+            </ul>
+            </li>
+            </ul>
+            HTML,
+            Menu::widget()
+                ->currentPath('/active')
+                ->dropdownContainerAttributes(['data-test' => 'value'])
+                ->items(
+                    [
+                        ['label' => 'Active', 'link' => '/active'],
+                        [
+                            'label' => 'Dropdown',
+                            'link' => '#',
+                            'items' => [
+                                ['label' => 'Action', 'link' => '#'],
+                            ],
+                        ],
+                    ],
+                )
+                ->render(),
+        );
+    }
+
     public function testDropdownContainerClass(): void
     {
         Assert::equalsWithoutLE(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Docs added?   | ❌
| Tests added?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  |

## What does this PR do?

Add `Menu::dropdownContainerAttributes()` method. The property `$dropdownContainerAttributes` existed and was used by `dropdownContainerClass()`, but there was no way to set arbitrary attributes directly. All other container types (`itemsContainer`, `itemContainer`) already have both `Attributes()` and `Class()` methods.

No BC break: new method only, existing API unchanged.

### Coverage

Menu.php: 196/196 (100%).
