### PR TITLE
Fix `encode` key leaking into `Breadcrumbs` HTML attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Enh #108: Bump minimal `yiisoft/html` version to `3.13` and add support for `^4.0` (@vjik)
 - Bug #113: Fix `array_merge()` argument order in `Menu::renderItem()` so that item-level `linkAttributes` override widget-level ones (@WarLikeLaux)
 - Enh #114: Add `readonly` to constructor-promoted properties in `Block`, `ContentDecorator`, and `FragmentCache` (@WarLikeLaux)
+- Bug #127: Fix `encode` key leaking into HTML attributes in `Breadcrumbs::renderItem()` (@WarLikeLaux)
 
 ## 2.1.1 September 23, 2025
 

--- a/src/Breadcrumbs.php
+++ b/src/Breadcrumbs.php
@@ -249,7 +249,7 @@ final class Breadcrumbs extends Widget
 
         if (isset($item['url']) && is_string($item['url'])) {
             $link = $item['url'];
-            unset($item['template'], $item['label'], $item['url']);
+            unset($item['template'], $item['label'], $item['url'], $item['encode']);
             $link = Html::a($label, $link, $item);
         } else {
             $link = $label;

--- a/tests/Breadcrumbs/BreadcrumbsTest.php
+++ b/tests/Breadcrumbs/BreadcrumbsTest.php
@@ -102,6 +102,18 @@ final class BreadcrumbsTest extends TestCase
         );
     }
 
+    public function testRenderItemEncodeKeyDoesNotLeakToAttributes(): void
+    {
+        $result = Breadcrumbs::widget()
+            ->homeItem(null)
+            ->items([['label' => 'Label', 'url' => '/path', 'encode' => false]])
+            ->tag('')
+            ->render();
+
+        $this->assertStringNotContainsString('encode=', $result);
+        $this->assertStringContainsString('<a href="/path">', $result);
+    }
+
     public function testRenderItemLabelOnlyEncodeLabelTrue(): void
     {
         $this->assertSame(

--- a/tests/Breadcrumbs/BreadcrumbsTest.php
+++ b/tests/Breadcrumbs/BreadcrumbsTest.php
@@ -134,7 +134,7 @@ final class BreadcrumbsTest extends TestCase
             ->tag('')
             ->render();
 
-        $this->assertStringNotContainsString('encode=', $result);
+        $this->assertDoesNotMatchRegularExpression('/<a\b[^>]*\sencode=/', $result);
         $this->assertStringContainsString('<a href="/path">', $result);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Docs added?   | ❌
| Tests added?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  |

## What does this PR do?

`Breadcrumbs::renderItem()` removes service keys (`template`, `label`, `url`) from the item array before passing it to `Html::a()` as attributes, but misses the `encode` key. When `'encode' => false` is set on an item with a URL, the rendered `<a>` tag gets a spurious `encode=""` attribute.

No BC break: only removes an unintended attribute from the output.