### PR TITLE
Add `separator()` method to `Breadcrumbs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Bug #113: Fix `array_merge()` argument order in `Menu::renderItem()` so that item-level `linkAttributes` override widget-level ones (@WarLikeLaux)
 - Enh #114: Add `readonly` to constructor-promoted properties in `Block`, `ContentDecorator`, and `FragmentCache` (@WarLikeLaux)
 - Enh #123: Remove redundant `array_merge()` call with single argument in `Dropdown` (@WarLikeLaux)
+- New #130: Add `separator()` method to `Breadcrumbs` widget (@WarLikeLaux)
 
 ## 2.1.1 September 23, 2025
 

--- a/src/Breadcrumbs.php
+++ b/src/Breadcrumbs.php
@@ -57,6 +57,7 @@ final class Breadcrumbs extends Widget
     private ?array $homeItem = ['label' => 'Home', 'url' => '/'];
     private array $items = [];
     private string $itemTemplate = "<li>{link}</li>\n";
+    private string $separator = '';
     private string $tag = 'ul';
 
     /**
@@ -169,6 +170,19 @@ final class Breadcrumbs extends Widget
     }
 
     /**
+     * Returns a new instance with the specified separator between breadcrumb items.
+     *
+     * @param string $value The separator string.
+     */
+    public function separator(string $value): self
+    {
+        $new = clone $this;
+        $new->separator = $value;
+
+        return $new;
+    }
+
+    /**
      * Returns a new instance with the specified tag.
      *
      * @param string $value The tag name.
@@ -211,7 +225,7 @@ final class Breadcrumbs extends Widget
             }
         }
 
-        $body = implode('', $items);
+        $body = implode($this->separator, $items);
 
         return empty($this->tag)
             ? $body

--- a/tests/Breadcrumbs/BreadcrumbsTest.php
+++ b/tests/Breadcrumbs/BreadcrumbsTest.php
@@ -115,6 +115,22 @@ final class BreadcrumbsTest extends TestCase
         );
     }
 
+    public function testSeparator(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <ul class="breadcrumb">
+            <li><a href="/">Home</a></li>
+             / <li class="active">My Home Page</li>
+            </ul>
+            HTML,
+            Breadcrumbs::widget()
+                ->separator(' / ')
+                ->items(['My Home Page'])
+                ->render(),
+        );
+    }
+
     public function testTag(): void
     {
         Assert::equalsWithoutLE(

--- a/tests/Breadcrumbs/ImmutableTest.php
+++ b/tests/Breadcrumbs/ImmutableTest.php
@@ -20,6 +20,7 @@ final class ImmutableTest extends TestCase
         $this->assertNotSame($breadcrumbs, $breadcrumbs->homeItem(null));
         $this->assertNotSame($breadcrumbs, $breadcrumbs->items(['label' => 'value']));
         $this->assertNotSame($breadcrumbs, $breadcrumbs->itemTemplate(''));
+        $this->assertNotSame($breadcrumbs, $breadcrumbs->separator(''));
         $this->assertNotSame($breadcrumbs, $breadcrumbs->tag('ul'));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Docs added?   | ❌
| Tests added?  | ✔️
| Breaks BC?    | ❌

## What does this PR do?

Add `separator()` method to `Breadcrumbs` widget for configuring a separator string between items.

No BC break: new method with empty string default, existing behavior unchanged.

### Coverage

9/9 methods (100%). Line coverage: 56/56 (100%).
