### PR TITLE
Add `firstItemClass()` and `lastItemClass()` to `Breadcrumbs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Bug #113: Fix `array_merge()` argument order in `Menu::renderItem()` so that item-level `linkAttributes` override widget-level ones (@WarLikeLaux)
 - Enh #114: Add `readonly` to constructor-promoted properties in `Block`, `ContentDecorator`, and `FragmentCache` (@WarLikeLaux)
 - Enh #123: Remove redundant `array_merge()` call with single argument in `Dropdown` (@WarLikeLaux)
+- New #131: Add `firstItemClass()` and `lastItemClass()` methods to `Breadcrumbs` widget (@WarLikeLaux)
 
 ## 2.1.1 September 23, 2025
 

--- a/src/Breadcrumbs.php
+++ b/src/Breadcrumbs.php
@@ -9,9 +9,11 @@ use Yiisoft\Html\Html;
 use Yiisoft\Widget\Widget;
 
 use function array_key_exists;
+use function count;
 use function implode;
 use function is_array;
 use function is_string;
+use function preg_replace;
 use function strtr;
 
 use const PHP_EOL;
@@ -54,9 +56,11 @@ final class Breadcrumbs extends Widget
 {
     private string $activeItemTemplate = "<li class=\"active\">{link}</li>\n";
     private array $attributes = ['class' => 'breadcrumb'];
+    private string $firstItemClass = '';
     private ?array $homeItem = ['label' => 'Home', 'url' => '/'];
     private array $items = [];
     private string $itemTemplate = "<li>{link}</li>\n";
+    private string $lastItemClass = '';
     private string $tag = 'ul';
 
     /**
@@ -82,6 +86,19 @@ final class Breadcrumbs extends Widget
     {
         $new = clone $this;
         $new->attributes = $valuesMap;
+
+        return $new;
+    }
+
+    /**
+     * Returns a new instance with the specified first item CSS class.
+     *
+     * @param string $value The CSS class that will be assigned to the first item in the breadcrumbs.
+     */
+    public function firstItemClass(string $value): self
+    {
+        $new = clone $this;
+        $new->firstItemClass = $value;
 
         return $new;
     }
@@ -169,6 +186,19 @@ final class Breadcrumbs extends Widget
     }
 
     /**
+     * Returns a new instance with the specified last item CSS class.
+     *
+     * @param string $value The CSS class that will be assigned to the last item in the breadcrumbs.
+     */
+    public function lastItemClass(string $value): self
+    {
+        $new = clone $this;
+        $new->lastItemClass = $value;
+
+        return $new;
+    }
+
+    /**
      * Returns a new instance with the specified tag.
      *
      * @param string $value The tag name.
@@ -211,11 +241,46 @@ final class Breadcrumbs extends Widget
             }
         }
 
+        if ($items !== []) {
+            $n = count($items);
+
+            if ($this->firstItemClass !== '') {
+                $items[0] = $this->addCssClassToFirstTag($items[0], $this->firstItemClass);
+            }
+
+            if ($this->lastItemClass !== '') {
+                $items[$n - 1] = $this->addCssClassToFirstTag($items[$n - 1], $this->lastItemClass);
+            }
+        }
+
         $body = implode('', $items);
 
         return empty($this->tag)
             ? $body
             : Html::normalTag($this->tag, PHP_EOL . $body, $this->attributes)->encode(false)->render();
+    }
+
+    private function addCssClassToFirstTag(string $html, string $class): string
+    {
+        $count = 0;
+        $result = preg_replace(
+            '/^(\s*<[a-z][a-z0-9]*\s[^>]*?\bclass=")/i',
+            '$1' . $class . ' ',
+            $html,
+            1,
+            $count,
+        );
+
+        if ($count > 0) {
+            return $result ?? $html;
+        }
+
+        return preg_replace(
+            '/^(\s*<[a-z][a-z0-9]*)/i',
+            '$1 class="' . $class . '"',
+            $html,
+            1,
+        ) ?? $html;
     }
 
     /**

--- a/tests/Breadcrumbs/BreadcrumbsTest.php
+++ b/tests/Breadcrumbs/BreadcrumbsTest.php
@@ -35,6 +35,55 @@ final class BreadcrumbsTest extends TestCase
         $this->assertEmpty(Breadcrumbs::widget()->render());
     }
 
+    public function testFirstItemClass(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <ul class="breadcrumb">
+            <li class="first"><a href="/">Home</a></li>
+            <li class="active">My Home Page</li>
+            </ul>
+            HTML,
+            Breadcrumbs::widget()
+                ->firstItemClass('first')
+                ->items(['My Home Page'])
+                ->render(),
+        );
+    }
+
+    public function testFirstItemClassWithExistingClass(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <ul class="breadcrumb">
+            <li class="first active">My Home Page</li>
+            </ul>
+            HTML,
+            Breadcrumbs::widget()
+                ->firstItemClass('first')
+                ->homeItem(null)
+                ->items(['My Home Page'])
+                ->render(),
+        );
+    }
+
+    public function testFirstItemClassAndLastItemClassOnSingleItem(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <ul class="breadcrumb">
+            <li class="last first active">Only Item</li>
+            </ul>
+            HTML,
+            Breadcrumbs::widget()
+                ->firstItemClass('first')
+                ->homeItem(null)
+                ->lastItemClass('last')
+                ->items(['Only Item'])
+                ->render(),
+        );
+    }
+
     public function testHomeItem(): void
     {
         Assert::equalsWithoutLE(
@@ -85,6 +134,22 @@ final class BreadcrumbsTest extends TestCase
                         ['label' => 'Text', 'template' => "<span>{link}</span>\n"],
                     ],
                 )
+                ->render(),
+        );
+    }
+
+    public function testLastItemClass(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <ul class="breadcrumb">
+            <li><a href="/">Home</a></li>
+            <li class="last active">My Home Page</li>
+            </ul>
+            HTML,
+            Breadcrumbs::widget()
+                ->lastItemClass('last')
+                ->items(['My Home Page'])
                 ->render(),
         );
     }

--- a/tests/Breadcrumbs/ImmutableTest.php
+++ b/tests/Breadcrumbs/ImmutableTest.php
@@ -17,9 +17,11 @@ final class ImmutableTest extends TestCase
         $breadcrumbs = Breadcrumbs::widget();
         $this->assertNotSame($breadcrumbs, $breadcrumbs->activeItemTemplate(''));
         $this->assertNotSame($breadcrumbs, $breadcrumbs->attributes([]));
+        $this->assertNotSame($breadcrumbs, $breadcrumbs->firstItemClass(''));
         $this->assertNotSame($breadcrumbs, $breadcrumbs->homeItem(null));
         $this->assertNotSame($breadcrumbs, $breadcrumbs->items(['label' => 'value']));
         $this->assertNotSame($breadcrumbs, $breadcrumbs->itemTemplate(''));
+        $this->assertNotSame($breadcrumbs, $breadcrumbs->lastItemClass(''));
         $this->assertNotSame($breadcrumbs, $breadcrumbs->tag('ul'));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Docs added?   | ❌
| Tests added?  | ✔️
| Breaks BC?    | ❌

## What does this PR do?

Add `firstItemClass()` and `lastItemClass()` methods to `Breadcrumbs`, matching the existing `Menu` API.

`Menu` applies these classes via `Html::addCssClass()` on an attributes array passed to `Html::normalTag()`. `Breadcrumbs` can't do the same because it renders items through string templates (`strtr($template, ['{link}' => $link])`), so the `<li>` tag is already baked into the template string. Switching to `Html::normalTag()` would be a BC break for anyone using custom `itemTemplate` / `activeItemTemplate`.

This PR uses regex to inject the class into the first HTML tag of the rendered item. If a refactor to `Html::normalTag()` is preferred, I can do that instead.

No BC break: new methods with empty string defaults, existing behavior unchanged.

### Coverage

11/11 methods (100%). Line coverage: 81/81 (100%).