### PR TITLE
Fix #132: Remove raw keys from normalized items in `Normalizer::dropdown()` and `Normalizer::menu()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Bug #113: Fix `array_merge()` argument order in `Menu::renderItem()` so that item-level `linkAttributes` override widget-level ones (@WarLikeLaux)
 - Enh #114: Add `readonly` to constructor-promoted properties in `Block`, `ContentDecorator`, and `FragmentCache` (@WarLikeLaux)
 - Enh #123: Remove redundant `array_merge()` call with single argument in `Dropdown` (@WarLikeLaux)
+- Enh #132: Remove raw keys from normalized items in `Normalizer::dropdown()` and `Normalizer::menu()` (@WarLikeLaux)
 
 ## 2.1.1 September 23, 2025
 

--- a/src/Helper/Normalizer.php
+++ b/src/Helper/Normalizer.php
@@ -34,6 +34,15 @@ final class Normalizer
                     self::iconClass($child),
                     self::iconContainerAttributes($child),
                 );
+
+                unset(
+                    $items[$i]['encode'],
+                    $items[$i]['icon'],
+                    $items[$i]['iconAttributes'],
+                    $items[$i]['iconClass'],
+                    $items[$i]['iconContainerAttributes'],
+                );
+
                 $items[$i]['active'] = self::active($child, '', '', false);
                 $items[$i]['disabled'] = self::disabled($child);
                 $items[$i]['enclose'] = self::enclose($child);
@@ -94,6 +103,14 @@ final class Normalizer
                         self::iconAttributes($child),
                         self::iconClass($child),
                         self::iconContainerAttributes($child, $iconContainerAttributes),
+                    );
+
+                    unset(
+                        $items[$i]['encode'],
+                        $items[$i]['icon'],
+                        $items[$i]['iconAttributes'],
+                        $items[$i]['iconClass'],
+                        $items[$i]['iconContainerAttributes'],
                     );
                 }
             }

--- a/tests/Helper/NormalizerTest.php
+++ b/tests/Helper/NormalizerTest.php
@@ -12,6 +12,52 @@ use Yiisoft\Yii\Widgets\Helper\Normalizer;
  */
 final class NormalizerTest extends TestCase
 {
+    public function testDropdownRemovesRawKeys(): void
+    {
+        $items = Normalizer::dropdown([
+            [
+                'label' => 'Item',
+                'link' => '#',
+                'encode' => false,
+                'icon' => 'home',
+                'iconAttributes' => ['class' => 'bi'],
+                'iconClass' => 'bi-home',
+                'iconContainerAttributes' => ['class' => 'icon'],
+            ],
+        ]);
+
+        $this->assertArrayNotHasKey('encode', $items[0]);
+        $this->assertArrayNotHasKey('icon', $items[0]);
+        $this->assertArrayNotHasKey('iconAttributes', $items[0]);
+        $this->assertArrayNotHasKey('iconClass', $items[0]);
+        $this->assertArrayNotHasKey('iconContainerAttributes', $items[0]);
+    }
+
+    public function testMenuRemovesRawKeys(): void
+    {
+        $items = Normalizer::menu(
+            [
+                [
+                    'label' => 'Item',
+                    'link' => '#',
+                    'encode' => false,
+                    'icon' => 'home',
+                    'iconAttributes' => ['class' => 'bi'],
+                    'iconClass' => 'bi-home',
+                    'iconContainerAttributes' => ['class' => 'icon'],
+                ],
+            ],
+            '',
+            false,
+        );
+
+        $this->assertArrayNotHasKey('encode', $items[0]);
+        $this->assertArrayNotHasKey('icon', $items[0]);
+        $this->assertArrayNotHasKey('iconAttributes', $items[0]);
+        $this->assertArrayNotHasKey('iconClass', $items[0]);
+        $this->assertArrayNotHasKey('iconContainerAttributes', $items[0]);
+    }
+
     public function testRenderLabel(): void
     {
         $this->assertSame('test', Normalizer::renderLabel('test', '', [], '', []));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Docs added?   | ❌
| Tests added?  | ✔️
| Breaks BC?    | ❌

## What does this PR do?

`Normalizer::dropdown()` and `Normalizer::menu()` extract `icon`, `iconAttributes`, `iconClass`, `iconContainerAttributes` via helper methods and pass them to `renderLabel()`. The `label()` helper also reads `encode`. After extraction, these keys stay in the normalized item array alongside the processed results (`label`, `active`, `link`, etc.).

This PR adds `unset()` for these five keys after they are consumed, so the normalized output only contains processed data.

Neither `Dropdown` nor `Menu` read these keys from normalized items, so removing them is safe.

No BC break: the normalized array is internal, not part of the public API.
