### PR TITLE
Fix `Alert::render()` ignoring header when body is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Bug #113: Fix `array_merge()` argument order in `Menu::renderItem()` so that item-level `linkAttributes` override widget-level ones (@WarLikeLaux)
 - Enh #114: Add `readonly` to constructor-promoted properties in `Block`, `ContentDecorator`, and `FragmentCache` (@WarLikeLaux)
 - Enh #123: Remove redundant `array_merge()` call with single argument in `Dropdown` (@WarLikeLaux)
+- Bug #133: Fix `Alert::render()` returning empty string when body is empty but header is set (@WarLikeLaux)
 
 ## 2.1.1 September 23, 2025
 

--- a/src/Alert.php
+++ b/src/Alert.php
@@ -445,6 +445,10 @@ final class Alert extends Widget
 
     public function render(): string
     {
+        if ($this->body === '' && $this->header === '') {
+            return '';
+        }
+
         $div = new Div();
         $parts = [];
 
@@ -459,14 +463,12 @@ final class Alert extends Widget
 
         $contentAlert = $this->renderHeaderContainer($parts) . PHP_EOL . $this->renderBodyContainer($parts);
 
-        return $this->body !== ''
-            ? $div
-                ->attribute('role', 'alert')
-                ->addAttributes($this->attributes)
-                ->content(PHP_EOL . trim($contentAlert) . PHP_EOL)
-                ->encode(false)
-                ->render()
-            : '';
+        return $div
+            ->attribute('role', 'alert')
+            ->addAttributes($this->attributes)
+            ->content(PHP_EOL . trim($contentAlert) . PHP_EOL)
+            ->encode(false)
+            ->render();
     }
 
     /**
@@ -502,6 +504,10 @@ final class Alert extends Widget
      */
     private function renderBody(): string
     {
+        if ($this->body === '') {
+            return '';
+        }
+
         return $this->bodyTag !== null
             ? Html::normalTag($this->bodyTag, $this->body, $this->bodyAttributes)->encode(false)->render()
             : $this->body;

--- a/tests/Alert/AlertTest.php
+++ b/tests/Alert/AlertTest.php
@@ -67,6 +67,11 @@ final class AlertTest extends TestCase
         );
     }
 
+    public function testEmptyBodyAndHeader(): void
+    {
+        $this->assertSame('', Alert::widget()->render());
+    }
+
     public function testGenerateId(): void
     {
         Assert::equalsWithoutLE(
@@ -117,6 +122,23 @@ final class AlertTest extends TestCase
                 ->header('Header title')
                 ->headerContainer()
                 ->headerContainerAttributes(['class' => 'test-class'])
+                ->id('w0-alert')
+                ->layoutHeader('{header}')
+                ->render(),
+        );
+    }
+
+    public function testHeaderWithoutBody(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <div role="alert" id="w0-alert">
+            <span>Header title</span>
+            <button type="button">&times;</button>
+            </div>
+            HTML,
+            Alert::widget()
+                ->header('Header title')
                 ->id('w0-alert')
                 ->layoutHeader('{header}')
                 ->render(),

--- a/tests/Alert/AlertTest.php
+++ b/tests/Alert/AlertTest.php
@@ -134,7 +134,7 @@ final class AlertTest extends TestCase
             <<<HTML
             <div role="alert" id="w0-alert">
             <span>Header title</span>
-            <button type="button">&times;</button>
+            <button aria-label="Close" type="button">&times;</button>
             </div>
             HTML,
             Alert::widget()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Docs added?   | ❌
| Tests added?  | ✔️
| Breaks BC?    | ❌

## What does this PR do?

`Alert::render()` checked only `$this->body !== ''` to decide whether to render. If a user set `header`, `icon`, or `button` but left `body` empty, the entire alert silently returned `''`.

This PR changes the guard to `$this->body === '' && $this->header === ''`, so header-only alerts now render. Two additional cleanups:

- Early return moved before `Html::generateId()` to avoid incrementing the ID counter for empty alerts.
- `renderBody()` returns `''` when body is empty instead of rendering an empty `<span></span>` tag.

No BC break: the only new behavior is that alerts with a header but no body now render. Previously this combination returned `''`, so no existing code could depend on the rendered output of a header-only alert.
