### PR TITLE
Add divider support to `Menu` widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Bug #113: Fix `array_merge()` argument order in `Menu::renderItem()` so that item-level `linkAttributes` override widget-level ones (@WarLikeLaux)
 - Enh #114: Add `readonly` to constructor-promoted properties in `Block`, `ContentDecorator`, and `FragmentCache` (@WarLikeLaux)
 - Enh #123: Remove redundant `array_merge()` call with single argument in `Dropdown` (@WarLikeLaux)
+- New #134: Add divider support to `Menu` widget (@WarLikeLaux)
 
 ## 2.1.1 September 23, 2025
 

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -15,6 +15,7 @@ use Yiisoft\Widget\Widget;
 
 use function array_merge;
 use function count;
+use function gettype;
 use function implode;
 use function strtr;
 use function trim;
@@ -56,6 +57,9 @@ final class Menu extends Widget
     private bool $container = true;
     private string $currentPath = '';
     private string $disabledClass = 'disabled';
+    private array $dividerAttributes = [];
+    private string $dividerClass = '';
+    private string $dividerTag = 'hr';
     private bool $dropdownContainer = true;
     private array $dropdownContainerAttributes = [];
     private string $dropdownContainerTag = 'li';
@@ -265,6 +269,45 @@ final class Menu extends Widget
     {
         $new = clone $this;
         $new->disabledClass = $value;
+
+        return $new;
+    }
+
+    /**
+     * Returns a new instance with the specified divider HTML attributes.
+     *
+     * @param array $valuesMap Attribute values indexed by attribute names.
+     */
+    public function dividerAttributes(array $valuesMap): self
+    {
+        $new = clone $this;
+        $new->dividerAttributes = $valuesMap;
+
+        return $new;
+    }
+
+    /**
+     * Returns a new instance with the specified divider class.
+     *
+     * @param string $value The divider class.
+     */
+    public function dividerClass(string $value): self
+    {
+        $new = clone $this;
+        $new->dividerClass = $value;
+
+        return $new;
+    }
+
+    /**
+     * Returns a new instance with the specified divider tag.
+     *
+     * @param string $value The divider tag.
+     */
+    public function dividerTag(string $value): self
+    {
+        $new = clone $this;
+        $new->dividerTag = $value;
 
         return $new;
     }
@@ -554,6 +597,32 @@ final class Menu extends Widget
             ->render();
     }
 
+    private function renderDivider(): string
+    {
+        $dividerAttributes = $this->dividerAttributes;
+
+        if ($this->dividerClass !== '') {
+            Html::addCssClass($dividerAttributes, $this->dividerClass);
+        }
+
+        if ($this->dividerTag === '') {
+            throw new InvalidArgumentException('Tag name must be a string and cannot be empty.');
+        }
+
+        $divider = Html::tag($this->dividerTag, '', $dividerAttributes)->encode(false)->render();
+
+        if ($this->itemsTag === '') {
+            throw new InvalidArgumentException('Tag name must be a string and cannot be empty.');
+        }
+
+        return match ($this->itemsContainer) {
+            false => $divider,
+            default => Html::normalTag($this->itemsTag, $divider, [])
+                ->encode(false)
+                ->render(),
+        };
+    }
+
     /**
      * @throws CircularReferenceException|InvalidConfigException|NotFoundException|NotInstantiableException
      */
@@ -647,7 +716,7 @@ final class Menu extends Widget
      *
      * @psalm-param array<
      *   array-key,
-     *   array{
+     *   string|array{
      *     label: string,
      *     link: string,
      *     linkAttributes: array,
@@ -665,6 +734,12 @@ final class Menu extends Widget
         $n = count($items);
 
         foreach ($items as $i => $item) {
+            if (gettype($item) === 'string') {
+                $lines[] = $this->renderDivider();
+
+                continue;
+            }
+
             if (isset($item['items'])) {
                 $lines[] = strtr($this->template, ['{items}' => $this->renderDropdown([$item])]);
             } elseif ($item['visible']) {

--- a/tests/Menu/ImmutableTest.php
+++ b/tests/Menu/ImmutableTest.php
@@ -30,6 +30,9 @@ final class ImmutableTest extends TestCase
         $this->assertNotSame($menu, $menu->container(false));
         $this->assertNotSame($menu, $menu->currentPath(''));
         $this->assertNotSame($menu, $menu->disabledClass(''));
+        $this->assertNotSame($menu, $menu->dividerAttributes([]));
+        $this->assertNotSame($menu, $menu->dividerClass(''));
+        $this->assertNotSame($menu, $menu->dividerTag('hr'));
         $this->assertNotSame($menu, $menu->dropdownContainerClass(''));
         $this->assertNotSame($menu, $menu->dropdownContainerTag('div'));
         $this->assertNotSame($menu, $menu->dropdownDefinitions([]));

--- a/tests/Menu/MenuTest.php
+++ b/tests/Menu/MenuTest.php
@@ -9,6 +9,7 @@ use Stringable;
 use Yiisoft\Yii\Widgets\Menu;
 use Yiisoft\Yii\Widgets\Tests\Support\Assert;
 use Yiisoft\Yii\Widgets\Tests\Support\TestTrait;
+use InvalidArgumentException;
 
 final class MenuTest extends TestCase
 {
@@ -249,7 +250,7 @@ final class MenuTest extends TestCase
 
     public function testDividerTagEmpty(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         Menu::widget()
             ->dividerTag('')

--- a/tests/Menu/MenuTest.php
+++ b/tests/Menu/MenuTest.php
@@ -185,6 +185,81 @@ final class MenuTest extends TestCase
         );
     }
 
+    public function testDivider(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <ul>
+            <li><a href="/">Home</a></li>
+            <li><hr></li>
+            <li><a href="/settings">Settings</a></li>
+            </ul>
+            HTML,
+            Menu::widget()
+                ->items([
+                    ['label' => 'Home', 'link' => '/'],
+                    '-',
+                    ['label' => 'Settings', 'link' => '/settings'],
+                ])
+                ->render(),
+        );
+    }
+
+    public function testDividerClass(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <ul>
+            <li><a href="/">Home</a></li>
+            <li><hr class="my-divider"></li>
+            <li><a href="/settings">Settings</a></li>
+            </ul>
+            HTML,
+            Menu::widget()
+                ->dividerClass('my-divider')
+                ->items([
+                    ['label' => 'Home', 'link' => '/'],
+                    '-',
+                    ['label' => 'Settings', 'link' => '/settings'],
+                ])
+                ->render(),
+        );
+    }
+
+    public function testDividerTag(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <ul>
+            <li><a href="/">Home</a></li>
+            <li><span></span></li>
+            <li><a href="/settings">Settings</a></li>
+            </ul>
+            HTML,
+            Menu::widget()
+                ->dividerTag('span')
+                ->items([
+                    ['label' => 'Home', 'link' => '/'],
+                    '-',
+                    ['label' => 'Settings', 'link' => '/settings'],
+                ])
+                ->render(),
+        );
+    }
+
+    public function testDividerTagEmpty(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        Menu::widget()
+            ->dividerTag('')
+            ->items([
+                ['label' => 'Home', 'link' => '/'],
+                '-',
+            ])
+            ->render();
+    }
+
     public function testDropdown(): void
     {
         Assert::equalsWithoutLE(

--- a/tests/Menu/MenuTest.php
+++ b/tests/Menu/MenuTest.php
@@ -261,6 +261,16 @@ final class MenuTest extends TestCase
             ->render();
     }
 
+    public function testDividerWithEmptyItemsTag(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        Menu::widget()
+            ->itemsTag('')
+            ->items(['-'])
+            ->render();
+    }
+
     public function testDropdown(): void
     {
         Assert::equalsWithoutLE(

--- a/tests/Menu/MenuTest.php
+++ b/tests/Menu/MenuTest.php
@@ -206,6 +206,27 @@ final class MenuTest extends TestCase
         );
     }
 
+    public function testDividerWithItemsContainerFalse(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <ul>
+            <a href="/">Home</a>
+            <hr>
+            <a href="/settings">Settings</a>
+            </ul>
+            HTML,
+            Menu::widget()
+                ->itemsContainer(false)
+                ->items([
+                    ['label' => 'Home', 'link' => '/'],
+                    '-',
+                    ['label' => 'Settings', 'link' => '/settings'],
+                ])
+                ->render(),
+        );
+    }
+
     public function testDividerClass(): void
     {
         Assert::equalsWithoutLE(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Docs added?   | ❌
| Tests added?  | ✔️
| Breaks BC?    | ❌

## What does this PR do?

Add divider support to `Menu`, matching the existing `Dropdown` API. Pass `'-'` as an item in `items()` to render a divider.

New methods: `dividerAttributes()`, `dividerClass()`, `dividerTag()`. Defaults: `<hr>` tag, no class.

`Normalizer::menu()` already skips non-array items (`if (is_array($child))`), so no normalizer changes needed.

No BC break: string items in `items()` were not supported before and would cause a type error during rendering.
