### PR TITLE
Fix #135: Add `maxItems()` truncation with ellipsis to `Breadcrumbs` widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Bug #113: Fix `array_merge()` argument order in `Menu::renderItem()` so that item-level `linkAttributes` override widget-level ones (@WarLikeLaux)
 - Enh #114: Add `readonly` to constructor-promoted properties in `Block`, `ContentDecorator`, and `FragmentCache` (@WarLikeLaux)
 - Enh #123: Remove redundant `array_merge()` call with single argument in `Dropdown` (@WarLikeLaux)
+- New #135: Add `maxItems()` truncation with ellipsis to `Breadcrumbs` widget (@WarLikeLaux)
 
 ## 2.1.1 September 23, 2025
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@
 - Bug #113: Fix `array_merge()` argument order in `Menu::renderItem()` so that item-level `linkAttributes` override widget-level ones (@WarLikeLaux)
 - Enh #114: Add `readonly` to constructor-promoted properties in `Block`, `ContentDecorator`, and `FragmentCache` (@WarLikeLaux)
 - Enh #123: Remove redundant `array_merge()` call with single argument in `Dropdown` (@WarLikeLaux)
-- New #135: Add `maxItems()` truncation with ellipsis to `Breadcrumbs` widget (@WarLikeLaux)
 - Enh #132: Remove raw keys from normalized items in `Normalizer::dropdown()` and `Normalizer::menu()` (@WarLikeLaux)
 - Bug #133: Fix `Alert::render()` returning empty string when body is empty but header is set (@WarLikeLaux)
 - New #126: Add `Menu::dropdownContainerAttributes()` method (@WarLikeLaux)
@@ -20,6 +19,7 @@
 - Bug #118: Add missing ARIA attributes to `Dropdown`, `Menu`, and `Alert` (@WarLikeLaux)
 - Enh #155: Add `url` as alias for `link` in `Menu` and `Dropdown` items (@WarLikeLaux)
 - Enh #157: Improve psalm type annotations (@Tigrov)
+- New #135: Add `maxItems()` truncation with ellipsis to `Breadcrumbs` widget (@WarLikeLaux)
 
 ## 2.1.1 September 23, 2025
 

--- a/src/Breadcrumbs.php
+++ b/src/Breadcrumbs.php
@@ -9,7 +9,10 @@ use Yiisoft\Html\Html;
 use Yiisoft\Widget\Widget;
 
 use function array_key_exists;
+use function array_slice;
+use function count;
 use function implode;
+use function intdiv;
 use function is_array;
 use function is_string;
 use function strtr;
@@ -54,9 +57,12 @@ final class Breadcrumbs extends Widget
 {
     private string $activeItemTemplate = "<li class=\"active\">{link}</li>\n";
     private array $attributes = ['class' => 'breadcrumb'];
+    private string $ellipsis = "\xe2\x80\xa6";
+    private string $ellipsisTemplate = "<li>{ellipsis}</li>\n";
     private ?array $homeItem = ['label' => 'Home', 'url' => '/'];
     private array $items = [];
     private string $itemTemplate = "<li>{link}</li>\n";
+    private int $maxItems = 0;
     private string $tag = 'ul';
 
     /**
@@ -82,6 +88,33 @@ final class Breadcrumbs extends Widget
     {
         $new = clone $this;
         $new->attributes = $valuesMap;
+
+        return $new;
+    }
+
+    /**
+     * Returns a new instance with the specified ellipsis text.
+     *
+     * @param string $value The ellipsis text used when items are truncated by {@see maxItems()}.
+     */
+    public function ellipsis(string $value): self
+    {
+        $new = clone $this;
+        $new->ellipsis = $value;
+
+        return $new;
+    }
+
+    /**
+     * Returns a new instance with the specified ellipsis template.
+     *
+     * @param string $value The template used to render the ellipsis item.
+     * The token `{ellipsis}` will be replaced with the ellipsis text.
+     */
+    public function ellipsisTemplate(string $value): self
+    {
+        $new = clone $this;
+        $new->ellipsisTemplate = $value;
 
         return $new;
     }
@@ -169,6 +202,19 @@ final class Breadcrumbs extends Widget
     }
 
     /**
+     * Returns a new instance with the specified maximum number of items to display.
+     *
+     * @param int $value The maximum number of displayed items including the ellipsis. 0 means unlimited.
+     */
+    public function maxItems(int $value): self
+    {
+        $new = clone $this;
+        $new->maxItems = $value;
+
+        return $new;
+    }
+
+    /**
      * Returns a new instance with the specified tag.
      *
      * @param string $value The tag name.
@@ -209,6 +255,17 @@ final class Breadcrumbs extends Widget
                     isset($item['url']) ? $this->itemTemplate : $this->activeItemTemplate,
                 );
             }
+        }
+
+        if ($this->maxItems > 0 && count($items) > $this->maxItems) {
+            $remaining = $this->maxItems - 1;
+            $headCount = intdiv($remaining, 2);
+            $tailCount = $remaining - $headCount;
+            $ellipsisItem = strtr($this->ellipsisTemplate, ['{ellipsis}' => $this->ellipsis]);
+
+            $head = array_slice($items, 0, $headCount);
+            $tail = $tailCount > 0 ? array_slice($items, -$tailCount) : [];
+            $items = [...$head, $ellipsisItem, ...$tail];
         }
 
         $body = implode('', $items);

--- a/src/Breadcrumbs.php
+++ b/src/Breadcrumbs.php
@@ -326,12 +326,19 @@ final class Breadcrumbs extends Widget
      *
      * This affects only the rendered HTML list. JSON-LD structured data still contains all breadcrumb items.
      *
-     * @param int $value The maximum number of displayed items including the ellipsis. 0 means unlimited.
+     * @param int|null $value The maximum number of displayed items including the ellipsis, or null for no limit.
+     * Must be a positive integer.
+     *
+     * @throws InvalidArgumentException If the value is not a positive integer or null.
      */
     public function maxItems(?int $value): self
     {
+        if ($value !== null && $value <= 0) {
+            throw new InvalidArgumentException('The "maxItems" value must be a positive integer or null.');
+        }
+
         $new = clone $this;
-        $new->maxItems = $value > 0 ? $value : null;
+        $new->maxItems = $value;
 
         return $new;
     }

--- a/src/Breadcrumbs.php
+++ b/src/Breadcrumbs.php
@@ -73,7 +73,10 @@ final class Breadcrumbs extends Widget
     private array $items = [];
     private string $itemTemplate = "<li>{link}</li>\n";
     private bool $jsonLd = false;
-    private int $maxItems = 0;
+    /**
+     * @psalm-var positive-int|null
+     */
+    private ?int $maxItems = null;
     private string $tag = 'ul';
 
     /**

--- a/src/Breadcrumbs.php
+++ b/src/Breadcrumbs.php
@@ -326,8 +326,10 @@ final class Breadcrumbs extends Widget
      *
      * This affects only the rendered HTML list. JSON-LD structured data still contains all breadcrumb items.
      *
-     * @param int|null $value The maximum number of displayed items including the ellipsis, or null for no limit.
-     * Must be a positive integer.
+     * @param int|null $value The maximum number of rendered breadcrumb items, including the home item and ellipsis,
+     * or null for no limit. Must be a positive integer.
+     *
+     * @psalm-param int|null $value
      *
      * @throws InvalidArgumentException If the value is not a positive integer or null.
      */

--- a/src/Breadcrumbs.php
+++ b/src/Breadcrumbs.php
@@ -67,7 +67,7 @@ final class Breadcrumbs extends Widget
     private string $containerClass = '';
     /** @psalm-var non-empty-string */
     private string $containerTag = 'nav';
-    private string $ellipsis = "\xe2\x80\xa6";
+    private string $ellipsis = '…';
     private string $ellipsisTemplate = "<li>{ellipsis}</li>\n";
     private ?array $homeItem = ['label' => 'Home', 'url' => '/'];
     private array $items = [];

--- a/src/Breadcrumbs.php
+++ b/src/Breadcrumbs.php
@@ -171,6 +171,7 @@ final class Breadcrumbs extends Widget
      * Returns a new instance with the specified ellipsis text.
      *
      * @param string $value The ellipsis text used when items are truncated by {@see maxItems()}.
+     * The value is inserted into the ellipsis template without encoding.
      */
     public function ellipsis(string $value): self
     {
@@ -323,12 +324,14 @@ final class Breadcrumbs extends Widget
     /**
      * Returns a new instance with the specified maximum number of items to display.
      *
+     * This affects only the rendered HTML list. JSON-LD structured data still contains all breadcrumb items.
+     *
      * @param int $value The maximum number of displayed items including the ellipsis. 0 means unlimited.
      */
     public function maxItems(int $value): self
     {
         $new = clone $this;
-        $new->maxItems = $value;
+        $new->maxItems = $value > 0 ? $value : null;
 
         return $new;
     }
@@ -379,7 +382,7 @@ final class Breadcrumbs extends Widget
             }
         }
 
-        if ($this->maxItems > 0 && count($items) > $this->maxItems) {
+        if ($this->maxItems !== null && count($items) > $this->maxItems) {
             $remaining = $this->maxItems - 1;
             $headCount = intdiv($remaining, 2);
             $tailCount = $remaining - $headCount;

--- a/src/Breadcrumbs.php
+++ b/src/Breadcrumbs.php
@@ -329,12 +329,13 @@ final class Breadcrumbs extends Widget
      * @param int|null $value The maximum number of rendered breadcrumb items, including the home item and ellipsis,
      * or null for no limit. Must be a positive integer.
      *
-     * @psalm-param int|null $value
+     * @psalm-param positive-int|null $value
      *
      * @throws InvalidArgumentException If the value is not a positive integer or null.
      */
     public function maxItems(?int $value): self
     {
+        /** @psalm-suppress DocblockTypeContradiction */
         if ($value !== null && $value <= 0) {
             throw new InvalidArgumentException('The "maxItems" value must be a positive integer or null.');
         }

--- a/src/Breadcrumbs.php
+++ b/src/Breadcrumbs.php
@@ -328,7 +328,7 @@ final class Breadcrumbs extends Widget
      *
      * @param int $value The maximum number of displayed items including the ellipsis. 0 means unlimited.
      */
-    public function maxItems(int $value): self
+    public function maxItems(?int $value): self
     {
         $new = clone $this;
         $new->maxItems = $value > 0 ? $value : null;

--- a/tests/Breadcrumbs/BreadcrumbsTest.php
+++ b/tests/Breadcrumbs/BreadcrumbsTest.php
@@ -35,6 +35,51 @@ final class BreadcrumbsTest extends TestCase
         $this->assertEmpty(Breadcrumbs::widget()->render());
     }
 
+    public function testEllipsis(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <ul class="breadcrumb">
+            <li><a href="/">Home</a></li>
+            <li>...</li>
+            <li class="active">Page</li>
+            </ul>
+            HTML,
+            Breadcrumbs::widget()
+                ->ellipsis('...')
+                ->maxItems(3)
+                ->items([
+                    ['label' => 'A', 'url' => '/a'],
+                    ['label' => 'B', 'url' => '/b'],
+                    'Page',
+                ])
+                ->render(),
+        );
+    }
+
+    public function testEllipsisTemplate(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <ul class="breadcrumb">
+            <li><a href="/">Home</a></li>
+            <li class="ellipsis">&hellip;</li>
+            <li class="active">Page</li>
+            </ul>
+            HTML,
+            Breadcrumbs::widget()
+                ->ellipsis('&hellip;')
+                ->ellipsisTemplate("<li class=\"ellipsis\">{ellipsis}</li>\n")
+                ->maxItems(3)
+                ->items([
+                    ['label' => 'A', 'url' => '/a'],
+                    ['label' => 'B', 'url' => '/b'],
+                    'Page',
+                ])
+                ->render(),
+        );
+    }
+
     public function testHomeItem(): void
     {
         Assert::equalsWithoutLE(
@@ -85,6 +130,74 @@ final class BreadcrumbsTest extends TestCase
                         ['label' => 'Text', 'template' => "<span>{link}</span>\n"],
                     ],
                 )
+                ->render(),
+        );
+    }
+
+    public function testMaxItems(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <ul class="breadcrumb">
+            <li><a href="/">Home</a></li>
+            <li><a href="/a">A</a></li>
+            <li>…</li>
+            <li><a href="/d">D</a></li>
+            <li class="active">Page</li>
+            </ul>
+            HTML,
+            Breadcrumbs::widget()
+                ->maxItems(5)
+                ->items([
+                    ['label' => 'A', 'url' => '/a'],
+                    ['label' => 'B', 'url' => '/b'],
+                    ['label' => 'C', 'url' => '/c'],
+                    ['label' => 'D', 'url' => '/d'],
+                    'Page',
+                ])
+                ->render(),
+        );
+    }
+
+    public function testMaxItemsWithinLimit(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <ul class="breadcrumb">
+            <li><a href="/">Home</a></li>
+            <li><a href="/a">A</a></li>
+            <li class="active">Page</li>
+            </ul>
+            HTML,
+            Breadcrumbs::widget()
+                ->maxItems(5)
+                ->items([
+                    ['label' => 'A', 'url' => '/a'],
+                    'Page',
+                ])
+                ->render(),
+        );
+    }
+
+    public function testMaxItemsWithoutHomeItem(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <ul class="breadcrumb">
+            <li><a href="/a">A</a></li>
+            <li>…</li>
+            <li class="active">Page</li>
+            </ul>
+            HTML,
+            Breadcrumbs::widget()
+                ->homeItem(null)
+                ->maxItems(3)
+                ->items([
+                    ['label' => 'A', 'url' => '/a'],
+                    ['label' => 'B', 'url' => '/b'],
+                    ['label' => 'C', 'url' => '/c'],
+                    'Page',
+                ])
                 ->render(),
         );
     }

--- a/tests/Breadcrumbs/BreadcrumbsTest.php
+++ b/tests/Breadcrumbs/BreadcrumbsTest.php
@@ -203,6 +203,28 @@ final class BreadcrumbsTest extends TestCase
         );
     }
 
+    public function testMaxItemsZero(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <ul class="breadcrumb">
+            <li><a href="/">Home</a></li>
+            <li><a href="/a">A</a></li>
+            <li><a href="/b">B</a></li>
+            <li class="active">Page</li>
+            </ul>
+            HTML,
+            Breadcrumbs::widget()
+                ->maxItems(0)
+                ->items([
+                    ['label' => 'A', 'url' => '/a'],
+                    ['label' => 'B', 'url' => '/b'],
+                    'Page',
+                ])
+                ->render(),
+        );
+    }
+
     public function testMaxItemsWithoutHomeItem(): void
     {
         Assert::equalsWithoutLE(

--- a/tests/Breadcrumbs/BreadcrumbsTest.php
+++ b/tests/Breadcrumbs/BreadcrumbsTest.php
@@ -158,26 +158,26 @@ final class BreadcrumbsTest extends TestCase
         );
     }
 
-    public function testMaxItems(): void
+    public function testMaxItemsTruncatesMiddleItems(): void
     {
         Assert::equalsWithoutLE(
             <<<HTML
             <ul class="breadcrumb">
             <li><a href="/">Home</a></li>
-            <li><a href="/a">A</a></li>
+            <li><a href="/catalog">Catalog</a></li>
             <li>…</li>
-            <li><a href="/d">D</a></li>
-            <li class="active">Page</li>
+            <li><a href="/catalog/phones/apple/iphone">iPhone</a></li>
+            <li class="active">iPhone 15 Pro</li>
             </ul>
             HTML,
             Breadcrumbs::widget()
                 ->maxItems(5)
                 ->items([
-                    ['label' => 'A', 'url' => '/a'],
-                    ['label' => 'B', 'url' => '/b'],
-                    ['label' => 'C', 'url' => '/c'],
-                    ['label' => 'D', 'url' => '/d'],
-                    'Page',
+                    ['label' => 'Catalog', 'url' => '/catalog'],
+                    ['label' => 'Phones', 'url' => '/catalog/phones'],
+                    ['label' => 'Apple', 'url' => '/catalog/phones/apple'],
+                    ['label' => 'iPhone', 'url' => '/catalog/phones/apple/iphone'],
+                    'iPhone 15 Pro',
                 ])
                 ->render(),
         );
@@ -189,15 +189,35 @@ final class BreadcrumbsTest extends TestCase
             <<<HTML
             <ul class="breadcrumb">
             <li><a href="/">Home</a></li>
-            <li><a href="/a">A</a></li>
-            <li class="active">Page</li>
+            <li><a href="/catalog">Catalog</a></li>
+            <li class="active">iPhone 15 Pro</li>
             </ul>
             HTML,
             Breadcrumbs::widget()
                 ->maxItems(5)
                 ->items([
-                    ['label' => 'A', 'url' => '/a'],
-                    'Page',
+                    ['label' => 'Catalog', 'url' => '/catalog'],
+                    'iPhone 15 Pro',
+                ])
+                ->render(),
+        );
+    }
+
+    public function testMaxItemsDoesNotTruncateWhenRenderedItemCountEqualsLimit(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <ul class="breadcrumb">
+            <li><a href="/">Home</a></li>
+            <li><a href="/catalog">Catalog</a></li>
+            <li class="active">iPhone 15 Pro</li>
+            </ul>
+            HTML,
+            Breadcrumbs::widget()
+                ->maxItems(3)
+                ->items([
+                    ['label' => 'Catalog', 'url' => '/catalog'],
+                    'iPhone 15 Pro',
                 ])
                 ->render(),
         );
@@ -208,19 +228,19 @@ final class BreadcrumbsTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <ul class="breadcrumb">
-            <li><a href="/a">A</a></li>
+            <li><a href="/catalog">Catalog</a></li>
             <li>…</li>
-            <li class="active">Page</li>
+            <li class="active">iPhone 15 Pro</li>
             </ul>
             HTML,
             Breadcrumbs::widget()
                 ->homeItem(null)
                 ->maxItems(3)
                 ->items([
-                    ['label' => 'A', 'url' => '/a'],
-                    ['label' => 'B', 'url' => '/b'],
-                    ['label' => 'C', 'url' => '/c'],
-                    'Page',
+                    ['label' => 'Catalog', 'url' => '/catalog'],
+                    ['label' => 'Phones', 'url' => '/catalog/phones'],
+                    ['label' => 'Apple', 'url' => '/catalog/phones/apple'],
+                    'iPhone 15 Pro',
                 ])
                 ->render(),
         );

--- a/tests/Breadcrumbs/BreadcrumbsTest.php
+++ b/tests/Breadcrumbs/BreadcrumbsTest.php
@@ -203,28 +203,6 @@ final class BreadcrumbsTest extends TestCase
         );
     }
 
-    public function testMaxItemsZero(): void
-    {
-        Assert::equalsWithoutLE(
-            <<<HTML
-            <ul class="breadcrumb">
-            <li><a href="/">Home</a></li>
-            <li><a href="/a">A</a></li>
-            <li><a href="/b">B</a></li>
-            <li class="active">Page</li>
-            </ul>
-            HTML,
-            Breadcrumbs::widget()
-                ->maxItems(0)
-                ->items([
-                    ['label' => 'A', 'url' => '/a'],
-                    ['label' => 'B', 'url' => '/b'],
-                    'Page',
-                ])
-                ->render(),
-        );
-    }
-
     public function testMaxItemsWithoutHomeItem(): void
     {
         Assert::equalsWithoutLE(

--- a/tests/Breadcrumbs/BreadcrumbsTest.php
+++ b/tests/Breadcrumbs/BreadcrumbsTest.php
@@ -158,7 +158,7 @@ final class BreadcrumbsTest extends TestCase
         );
     }
 
-    public function testMaxItemsTruncatesMiddleItems(): void
+    public function testMaxItemsTruncates(): void
     {
         Assert::equalsWithoutLE(
             <<<HTML
@@ -203,7 +203,7 @@ final class BreadcrumbsTest extends TestCase
         );
     }
 
-    public function testMaxItemsDoesNotTruncateWhenRenderedItemCountEqualsLimit(): void
+    public function testMaxItemsAtLimit(): void
     {
         Assert::equalsWithoutLE(
             <<<HTML

--- a/tests/Breadcrumbs/BreadcrumbsTest.php
+++ b/tests/Breadcrumbs/BreadcrumbsTest.php
@@ -246,6 +246,26 @@ final class BreadcrumbsTest extends TestCase
         );
     }
 
+    public function testMaxItemsWithoutHomeItemAtLimit(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <ul class="breadcrumb">
+            <li><a href="/catalog">Catalog</a></li>
+            <li class="active">iPhone 15 Pro</li>
+            </ul>
+            HTML,
+            Breadcrumbs::widget()
+                ->homeItem(null)
+                ->maxItems(2)
+                ->items([
+                    ['label' => 'Catalog', 'url' => '/catalog'],
+                    'iPhone 15 Pro',
+                ])
+                ->render(),
+        );
+    }
+
     public function testRenderItemLabelOnlyEncodeLabelFalse(): void
     {
         $this->assertSame(

--- a/tests/Breadcrumbs/ExceptionTest.php
+++ b/tests/Breadcrumbs/ExceptionTest.php
@@ -44,4 +44,18 @@ final class ExceptionTest extends TestCase
         $this->expectExceptionMessage('The "label" element is required for each item.');
         Breadcrumbs::widget()->homeItem(null)->items([['url' => 'http://my.example.com/yii2/link/page']])->render();
     }
+
+    public function testMaxItemsZero(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "maxItems" value must be a positive integer or null.');
+        Breadcrumbs::widget()->maxItems(0);
+    }
+
+    public function testMaxItemsNegative(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "maxItems" value must be a positive integer or null.');
+        Breadcrumbs::widget()->maxItems(-1);
+    }
 }

--- a/tests/Breadcrumbs/ImmutableTest.php
+++ b/tests/Breadcrumbs/ImmutableTest.php
@@ -17,9 +17,12 @@ final class ImmutableTest extends TestCase
         $breadcrumbs = Breadcrumbs::widget();
         $this->assertNotSame($breadcrumbs, $breadcrumbs->activeItemTemplate(''));
         $this->assertNotSame($breadcrumbs, $breadcrumbs->attributes([]));
+        $this->assertNotSame($breadcrumbs, $breadcrumbs->ellipsis(''));
+        $this->assertNotSame($breadcrumbs, $breadcrumbs->ellipsisTemplate(''));
         $this->assertNotSame($breadcrumbs, $breadcrumbs->homeItem(null));
         $this->assertNotSame($breadcrumbs, $breadcrumbs->items(['label' => 'value']));
         $this->assertNotSame($breadcrumbs, $breadcrumbs->itemTemplate(''));
+        $this->assertNotSame($breadcrumbs, $breadcrumbs->maxItems(0));
         $this->assertNotSame($breadcrumbs, $breadcrumbs->tag('ul'));
     }
 }

--- a/tests/Breadcrumbs/ImmutableTest.php
+++ b/tests/Breadcrumbs/ImmutableTest.php
@@ -28,7 +28,7 @@ final class ImmutableTest extends TestCase
         $this->assertNotSame($breadcrumbs, $breadcrumbs->items(['label' => 'value']));
         $this->assertNotSame($breadcrumbs, $breadcrumbs->itemTemplate(''));
         $this->assertNotSame($breadcrumbs, $breadcrumbs->jsonLd(true));
-        $this->assertNotSame($breadcrumbs, $breadcrumbs->maxItems(0));
+        $this->assertNotSame($breadcrumbs, $breadcrumbs->maxItems(5));
         $this->assertNotSame($breadcrumbs, $breadcrumbs->tag('ul'));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Docs added?   | ❌
| Tests added?  | ✔️
| Breaks BC?    | ❌

## What does this PR do?

Add `maxItems()` truncation to `Breadcrumbs`. When the total number of rendered items exceeds `maxItems`, middle items are collapsed into a configurable ellipsis element.

New methods: `maxItems()`, `ellipsis()`, `ellipsisTemplate()`.

When truncating, available slots (minus 1 for ellipsis) are split between head and tail, favoring tail items (closer to the current page). For example, `maxItems(5)` with 7 items renders: 2 head + ellipsis + 2 tail.

No BC break: `maxItems` defaults to `0` (unlimited), preserving current behavior.
