### PR TITLE
Add active trail support to `Menu` widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Bug #113: Fix `array_merge()` argument order in `Menu::renderItem()` so that item-level `linkAttributes` override widget-level ones (@WarLikeLaux)
 - Enh #114: Add `readonly` to constructor-promoted properties in `Block`, `ContentDecorator`, and `FragmentCache` (@WarLikeLaux)
 - Enh #123: Remove redundant `array_merge()` call with single argument in `Dropdown` (@WarLikeLaux)
+- New #136: Add active trail support to `Menu` widget (@WarLikeLaux)
 
 ## 2.1.1 September 23, 2025
 

--- a/src/Helper/Normalizer.php
+++ b/src/Helper/Normalizer.php
@@ -13,6 +13,7 @@ use function array_key_exists;
 use function is_array;
 use function is_bool;
 use function is_string;
+use function str_starts_with;
 
 final class Normalizer
 {
@@ -63,6 +64,7 @@ final class Normalizer
         string $currentPath,
         bool $activateItems,
         array $iconContainerAttributes = [],
+        bool $activeTrail = false,
     ): array {
         /**
          * @psalm-var array[] $items
@@ -86,6 +88,8 @@ final class Normalizer
                         $currentPath,
                         $activateItems,
                     );
+                    $items[$i]['activeTrail'] = !$items[$i]['active']
+                        && self::isItemInActiveTrail($items[$i]['link'], $currentPath, $activeTrail);
                     $items[$i]['disabled'] = self::disabled($child);
                     $items[$i]['visible'] = self::visible($child);
                     $items[$i]['label'] = self::renderLabel(
@@ -173,6 +177,11 @@ final class Normalizer
     {
         return array_key_exists('iconContainerAttributes', $item) && is_array($item['iconContainerAttributes'])
             ? $item['iconContainerAttributes'] : $iconContainerAttributes;
+    }
+
+    private static function isItemInActiveTrail(string $link, string $currentPath, bool $activeTrail): bool
+    {
+        return $activeTrail && $link !== '' && str_starts_with($currentPath, $link . '/');
     }
 
     /**

--- a/src/Helper/Normalizer.php
+++ b/src/Helper/Normalizer.php
@@ -13,7 +13,6 @@ use function array_key_exists;
 use function is_array;
 use function is_bool;
 use function is_string;
-use function str_starts_with;
 
 final class Normalizer
 {
@@ -87,7 +86,18 @@ final class Normalizer
                         $currentPath,
                         $activateItems,
                         $iconContainerAttributes,
+                        $activeTrail,
                     );
+                    $link = self::link($child);
+                    $items[$i]['active'] = self::active(
+                        $child,
+                        $link,
+                        $currentPath,
+                        $activateItems,
+                    );
+                    $items[$i]['activeTrail'] = $activeTrail
+                        && !$items[$i]['active']
+                        && self::hasActiveDescendant($items[$i]['items']);
                 } else {
                     $items[$i]['link'] = self::link($child);
                     $items[$i]['linkAttributes'] = self::linkAttributes($child);
@@ -97,8 +107,7 @@ final class Normalizer
                         $currentPath,
                         $activateItems,
                     );
-                    $items[$i]['activeTrail'] = !$items[$i]['active']
-                        && self::isItemInActiveTrail($items[$i]['link'], $currentPath, $activeTrail);
+                    $items[$i]['activeTrail'] = false;
                     $items[$i]['disabled'] = self::disabled($child);
                     $items[$i]['visible'] = self::visible($child);
                     $items[$i]['label'] = self::renderLabel(
@@ -196,9 +205,22 @@ final class Normalizer
             ? $item['iconContainerAttributes'] : $iconContainerAttributes;
     }
 
-    private static function isItemInActiveTrail(string $link, string $currentPath, bool $activeTrail): bool
+    private static function hasActiveDescendant(array $items): bool
     {
-        return $activeTrail && $link !== '' && str_starts_with($currentPath, $link . '/');
+        foreach ($items as $item) {
+            if (
+                is_array($item)
+                && (
+                    ($item['active'] ?? false)
+                    || ($item['activeTrail'] ?? false)
+                    || (isset($item['items']) && is_array($item['items']) && self::hasActiveDescendant($item['items']))
+                )
+            ) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/src/Helper/Normalizer.php
+++ b/src/Helper/Normalizer.php
@@ -73,6 +73,9 @@ final class Normalizer
         bool $activateItems,
         array $iconContainerAttributes = [],
         bool $activeTrail = false,
+        string $activeTrailClass = '',
+        array $dropdownToggleAttributes = [],
+        string $dropdownToggleClass = '',
     ): array {
         /**
          * @psalm-var array[] $items
@@ -87,6 +90,9 @@ final class Normalizer
                         $activateItems,
                         $iconContainerAttributes,
                         $activeTrail,
+                        $activeTrailClass,
+                        $dropdownToggleAttributes,
+                        $dropdownToggleClass,
                     );
                     $link = self::link($child);
                     $items[$i]['active'] = self::active(
@@ -98,6 +104,15 @@ final class Normalizer
                     $items[$i]['activeTrail'] = $activeTrail
                         && !$items[$i]['active']
                         && self::hasActiveDescendant($items[$i]['items']);
+
+                    if ($items[$i]['activeTrail'] && $activeTrailClass !== '') {
+                        $items[$i]['toggleAttributes'] = self::activeTrailToggleAttributes(
+                            $child,
+                            $activeTrailClass,
+                            $dropdownToggleAttributes,
+                            $dropdownToggleClass,
+                        );
+                    }
                 } else {
                     $items[$i]['link'] = self::link($child);
                     $items[$i]['linkAttributes'] = self::linkAttributes($child);
@@ -164,6 +179,23 @@ final class Normalizer
         }
 
         return is_bool($item['active']) ? $item['active'] : false;
+    }
+
+    private static function activeTrailToggleAttributes(
+        array $item,
+        string $activeTrailClass,
+        array $dropdownToggleAttributes,
+        string $dropdownToggleClass,
+    ): array {
+        $toggleAttributes = array_merge($dropdownToggleAttributes, self::toggleAttributes($item));
+
+        if ($dropdownToggleClass !== '') {
+            Html::addCssClass($toggleAttributes, $dropdownToggleClass);
+        }
+
+        Html::addCssClass($toggleAttributes, $activeTrailClass);
+
+        return $toggleAttributes;
     }
 
     private static function disabled(array $item): bool

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -49,6 +49,8 @@ final class Menu extends Widget
     private string $afterTag = 'span';
     private string $activeClass = 'active';
     private bool $activateItems = true;
+    private bool $activeTrail = false;
+    private string $activeTrailClass = 'active-trail';
     private array $attributes = [];
     private array $beforeAttributes = [];
     private string $beforeContent = '';
@@ -96,6 +98,32 @@ final class Menu extends Widget
     {
         $new = clone $this;
         $new->activeClass = $value;
+
+        return $new;
+    }
+
+    /**
+     * Returns a new instance with active trail enabled or disabled.
+     *
+     * @param bool $value Whether to highlight ancestor items of the active item.
+     */
+    public function activeTrail(bool $value): self
+    {
+        $new = clone $this;
+        $new->activeTrail = $value;
+
+        return $new;
+    }
+
+    /**
+     * Returns a new instance with the specified active trail CSS class.
+     *
+     * @param string $value The CSS class to be appended to ancestor items of the active item.
+     */
+    public function activeTrailClass(string $value): self
+    {
+        $new = clone $this;
+        $new->activeTrailClass = $value;
 
         return $new;
     }
@@ -526,6 +554,7 @@ final class Menu extends Widget
             $this->currentPath,
             $this->activateItems,
             $this->iconContainerAttributes,
+            $this->activeTrail,
         );
 
         return $this->renderMenu($items);
@@ -601,6 +630,7 @@ final class Menu extends Widget
      *   link: string,
      *   linkAttributes: array,
      *   active: bool,
+     *   activeTrail?: bool,
      *   disabled: bool,
      *   visible: bool,
      *   items?: array,
@@ -618,6 +648,10 @@ final class Menu extends Widget
         if ($item['active']) {
             $linkAttributes['aria-current'] = 'page';
             Html::addCssClass($linkAttributes, $this->activeClass);
+        }
+
+        if ($item['activeTrail'] ?? false) {
+            Html::addCssClass($linkAttributes, $this->activeTrailClass);
         }
 
         if ($item['disabled']) {

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -16,6 +16,8 @@ use Yiisoft\Widget\Widget;
 use function array_merge;
 use function count;
 use function implode;
+use function is_array;
+use function is_string;
 use function strtr;
 use function trim;
 
@@ -577,6 +579,7 @@ final class Menu extends Widget
          *     link: string,
          *     linkAttributes: array,
          *     active: bool,
+         *     activeTrail?: bool,
          *     disabled: bool,
          *     visible: bool,
          *     items?: array
@@ -592,6 +595,57 @@ final class Menu extends Widget
         );
 
         return $this->renderMenu($items);
+    }
+
+    private function addActiveTrailClassToDropdownToggles(
+        array $item,
+        array $toggleAttributes,
+        string $toggleClass,
+    ): array {
+        if (($item['activeTrail'] ?? false) && $this->activeTrailClass !== '') {
+            $itemToggleAttributes = $item['toggleAttributes'] ?? [];
+            $itemToggleAttributes = is_array($itemToggleAttributes) ? $itemToggleAttributes : [];
+            $itemToggleAttributes = array_merge($toggleAttributes, $itemToggleAttributes);
+
+            if ($toggleClass !== '') {
+                Html::addCssClass($itemToggleAttributes, $toggleClass);
+            }
+
+            Html::addCssClass($itemToggleAttributes, $this->activeTrailClass);
+            $item['toggleAttributes'] = $itemToggleAttributes;
+        }
+
+        $items = $item['items'] ?? [];
+
+        if (is_array($items)) {
+            foreach ($items as $i => $child) {
+                if (is_array($child)) {
+                    $items[$i] = $this->addActiveTrailClassToDropdownToggles(
+                        $child,
+                        $toggleAttributes,
+                        $toggleClass,
+                    );
+                }
+            }
+
+            $item['items'] = $items;
+        }
+
+        return $item;
+    }
+
+    private function dropdownToggleAttributes(array $dropdownDefinitions): array
+    {
+        $toggleAttributes = $dropdownDefinitions['toggleAttributes()'][0] ?? [];
+
+        return is_array($toggleAttributes) ? $toggleAttributes : [];
+    }
+
+    private function dropdownToggleClass(array $dropdownDefinitions): string
+    {
+        $toggleClass = $dropdownDefinitions['toggleClass()'][0] ?? '';
+
+        return is_string($toggleClass) ? $toggleClass : '';
     }
 
     private function renderAfterContent(): string
@@ -633,6 +687,15 @@ final class Menu extends Widget
                 ],
                 'toggleType()' => ['link'],
             ];
+        }
+
+        $toggleAttributes = $this->dropdownToggleAttributes($dropdownDefinitions);
+        $toggleClass = $this->dropdownToggleClass($dropdownDefinitions);
+
+        foreach ($items as $i => $item) {
+            if (is_array($item)) {
+                $items[$i] = $this->addActiveTrailClassToDropdownToggles($item, $toggleAttributes, $toggleClass);
+            }
         }
 
         $dropdown = Dropdown::widget([], $dropdownDefinitions)->items($items)->render();
@@ -721,6 +784,7 @@ final class Menu extends Widget
      *     link: string,
      *     linkAttributes: array,
      *     active: bool,
+     *     activeTrail?: bool,
      *     disabled: bool,
      *     visible: bool,
      *     items?: array,
@@ -783,6 +847,7 @@ final class Menu extends Widget
      *     link: string,
      *     linkAttributes: array,
      *     active: bool,
+     *     activeTrail?: bool,
      *     disabled: bool,
      *     visible: bool,
      *     items?: array

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -747,10 +747,6 @@ final class Menu extends Widget
             Html::addCssClass($linkAttributes, $this->activeClass);
         }
 
-        if ($item['activeTrail'] ?? false) {
-            Html::addCssClass($linkAttributes, $this->activeTrailClass);
-        }
-
         if ($item['disabled']) {
             $linkAttributes['aria-disabled'] = 'true';
             Html::addCssClass($linkAttributes, $this->disabledClass);

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -571,6 +571,8 @@ final class Menu extends Widget
             return '';
         }
 
+        $dropdownDefinitions = $this->dropdownDefinitionsWithDefaults();
+
         /**
          * @psalm-var array<
          *   array-key,
@@ -592,46 +594,12 @@ final class Menu extends Widget
             $this->activateItems,
             $this->iconContainerAttributes,
             $this->activeTrail,
+            $this->activeTrailClass,
+            $this->dropdownToggleAttributes($dropdownDefinitions),
+            $this->dropdownToggleClass($dropdownDefinitions),
         );
 
         return $this->renderMenu($items);
-    }
-
-    private function addActiveTrailClassToDropdownToggles(
-        array $item,
-        array $toggleAttributes,
-        string $toggleClass,
-    ): array {
-        if (($item['activeTrail'] ?? false) && $this->activeTrailClass !== '') {
-            $itemToggleAttributes = $item['toggleAttributes'] ?? [];
-            $itemToggleAttributes = is_array($itemToggleAttributes) ? $itemToggleAttributes : [];
-            $itemToggleAttributes = array_merge($toggleAttributes, $itemToggleAttributes);
-
-            if ($toggleClass !== '') {
-                Html::addCssClass($itemToggleAttributes, $toggleClass);
-            }
-
-            Html::addCssClass($itemToggleAttributes, $this->activeTrailClass);
-            $item['toggleAttributes'] = $itemToggleAttributes;
-        }
-
-        $items = $item['items'] ?? [];
-
-        if (is_array($items)) {
-            foreach ($items as $i => $child) {
-                if (is_array($child)) {
-                    $items[$i] = $this->addActiveTrailClassToDropdownToggles(
-                        $child,
-                        $toggleAttributes,
-                        $toggleClass,
-                    );
-                }
-            }
-
-            $item['items'] = $items;
-        }
-
-        return $item;
     }
 
     private function dropdownToggleAttributes(array $dropdownDefinitions): array
@@ -646,6 +614,22 @@ final class Menu extends Widget
         $toggleClass = $dropdownDefinitions['toggleClass()'][0] ?? '';
 
         return is_string($toggleClass) ? $toggleClass : '';
+    }
+
+    private function dropdownDefinitionsWithDefaults(): array
+    {
+        if ($this->dropdownDefinitions !== []) {
+            return $this->dropdownDefinitions;
+        }
+
+        return [
+            'container()' => [false],
+            'dividerClass()' => ['dropdown-divider'],
+            'toggleAttributes()' => [
+                ['aria-expanded' => 'false', 'data-bs-toggle' => 'dropdown', 'role' => 'button'],
+            ],
+            'toggleType()' => ['link'],
+        ];
     }
 
     private function renderAfterContent(): string
@@ -676,29 +660,7 @@ final class Menu extends Widget
      */
     private function renderDropdown(array $items): string
     {
-        $dropdownDefinitions = $this->dropdownDefinitions;
-
-        if ($dropdownDefinitions === []) {
-            $dropdownDefinitions = [
-                'container()' => [false],
-                'dividerClass()' => ['dropdown-divider'],
-                'toggleAttributes()' => [
-                    ['aria-expanded' => 'false', 'data-bs-toggle' => 'dropdown', 'role' => 'button'],
-                ],
-                'toggleType()' => ['link'],
-            ];
-        }
-
-        $toggleAttributes = $this->dropdownToggleAttributes($dropdownDefinitions);
-        $toggleClass = $this->dropdownToggleClass($dropdownDefinitions);
-
-        foreach ($items as $i => $item) {
-            if (is_array($item)) {
-                $items[$i] = $this->addActiveTrailClassToDropdownToggles($item, $toggleAttributes, $toggleClass);
-            }
-        }
-
-        $dropdown = Dropdown::widget([], $dropdownDefinitions)->items($items)->render();
+        $dropdown = Dropdown::widget([], $this->dropdownDefinitionsWithDefaults())->items($items)->render();
 
         if ($this->dropdownContainerTag === '') {
             throw new InvalidArgumentException('Tag name must be a string and cannot be empty.');

--- a/tests/Helper/NormalizerTest.php
+++ b/tests/Helper/NormalizerTest.php
@@ -58,6 +58,40 @@ final class NormalizerTest extends TestCase
         $this->assertArrayNotHasKey('iconContainerAttributes', $items[0]);
     }
 
+    public function testMenuSetsActiveTrailToggleAttributes(): void
+    {
+        $items = Normalizer::menu(
+            [
+                [
+                    'label' => 'Products',
+                    'link' => '/catalog',
+                    'toggleAttributes' => ['class' => 'custom-toggle', 'data-id' => 'products'],
+                    'items' => [
+                        ['label' => 'Phones', 'link' => '/phones'],
+                    ],
+                ],
+            ],
+            '/phones',
+            true,
+            [],
+            true,
+            'active-trail',
+            ['aria-expanded' => 'false', 'role' => 'button'],
+            'dropdown-toggle',
+        );
+
+        $this->assertTrue($items[0]['activeTrail']);
+        $this->assertSame(
+            [
+                'aria-expanded' => 'false',
+                'role' => 'button',
+                'class' => 'custom-toggle dropdown-toggle active-trail',
+                'data-id' => 'products',
+            ],
+            $items[0]['toggleAttributes'],
+        );
+    }
+
     public function testRenderLabel(): void
     {
         $this->assertSame('test', Normalizer::renderLabel('test', '', [], '', []));

--- a/tests/Menu/ImmutableTest.php
+++ b/tests/Menu/ImmutableTest.php
@@ -21,6 +21,8 @@ final class ImmutableTest extends TestCase
         $this->assertNotSame($menu, $menu->afterContent(''));
         $this->assertNotSame($menu, $menu->afterTag(''));
         $this->assertNotSame($menu, $menu->activeClass(''));
+        $this->assertNotSame($menu, $menu->activeTrail(false));
+        $this->assertNotSame($menu, $menu->activeTrailClass(''));
         $this->assertNotSame($menu, $menu->attributes([]));
         $this->assertNotSame($menu, $menu->beforeAttributes([]));
         $this->assertNotSame($menu, $menu->beforeClass(''));

--- a/tests/Menu/MenuTest.php
+++ b/tests/Menu/MenuTest.php
@@ -48,6 +48,73 @@ final class MenuTest extends TestCase
         );
     }
 
+    public function testActiveTrail(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <ul>
+            <li><a href="/">Home</a></li>
+            <li><a class="active-trail" href="/products">Products</a></li>
+            <li><a class="active-trail" href="/products/electronics">Electronics</a></li>
+            <li><a aria-current="page" class="active" href="/products/electronics/phones">Phones</a></li>
+            <li><a href="/about">About</a></li>
+            </ul>
+            HTML,
+            Menu::widget()
+                ->activeTrail(true)
+                ->currentPath('/products/electronics/phones')
+                ->items([
+                    ['label' => 'Home', 'link' => '/'],
+                    ['label' => 'Products', 'link' => '/products'],
+                    ['label' => 'Electronics', 'link' => '/products/electronics'],
+                    ['label' => 'Phones', 'link' => '/products/electronics/phones'],
+                    ['label' => 'About', 'link' => '/about'],
+                ])
+                ->render(),
+        );
+    }
+
+    public function testActiveTrailClass(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <ul>
+            <li><a class="trail" href="/products">Products</a></li>
+            <li><a aria-current="page" class="active" href="/products/phones">Phones</a></li>
+            </ul>
+            HTML,
+            Menu::widget()
+                ->activeTrail(true)
+                ->activeTrailClass('trail')
+                ->currentPath('/products/phones')
+                ->items([
+                    ['label' => 'Products', 'link' => '/products'],
+                    ['label' => 'Phones', 'link' => '/products/phones'],
+                ])
+                ->render(),
+        );
+    }
+
+    public function testActiveTrailDoesNotMatchSubstring(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <ul>
+            <li><a href="/prod">Prod</a></li>
+            <li><a aria-current="page" class="active" href="/products">Products</a></li>
+            </ul>
+            HTML,
+            Menu::widget()
+                ->activeTrail(true)
+                ->currentPath('/products')
+                ->items([
+                    ['label' => 'Prod', 'link' => '/prod'],
+                    ['label' => 'Products', 'link' => '/products'],
+                ])
+                ->render(),
+        );
+    }
+
     public function testAfter(): void
     {
         Assert::equalsWithoutLE(

--- a/tests/Menu/MenuTest.php
+++ b/tests/Menu/MenuTest.php
@@ -72,8 +72,8 @@ final class MenuTest extends TestCase
             <ul>
             <li><a href="/">Home</a></li>
             <li>
-            <a aria-expanded="false" data-bs-toggle="dropdown" role="button" class="active-trail" href="/catalog">Products</a>
-            <ul>
+            <a aria-expanded="false" data-bs-toggle="dropdown" role="button" class="active-trail" id="dropdown-1" href="/catalog">Products</a>
+            <ul aria-labelledby="dropdown-1">
             <li><a aria-current="page" class="active" href="/phones">Phones</a></li>
             </ul>
             </li>
@@ -104,8 +104,8 @@ final class MenuTest extends TestCase
             <<<HTML
             <ul>
             <li>
-            <a aria-expanded="false" data-bs-toggle="dropdown" role="button" class="trail" href="/catalog">Products</a>
-            <ul>
+            <a aria-expanded="false" data-bs-toggle="dropdown" role="button" class="trail" id="dropdown-1" href="/catalog">Products</a>
+            <ul aria-labelledby="dropdown-1">
             <li><a aria-current="page" class="active" href="/phones">Phones</a></li>
             </ul>
             </li>
@@ -134,8 +134,8 @@ final class MenuTest extends TestCase
             <<<HTML
             <ul>
             <li>
-            <a aria-expanded="false" data-bs-toggle="dropdown" role="button" class="dropdown-toggle active-trail" href="/catalog">Products</a>
-            <ul class="dropdown-menu">
+            <a aria-expanded="false" data-bs-toggle="dropdown" role="button" class="dropdown-toggle active-trail" id="dropdown-1" href="/catalog">Products</a>
+            <ul class="dropdown-menu" aria-labelledby="dropdown-1">
             <li><a class="dropdown-item active" aria-current="page" href="/phones">Phones</a></li>
             </ul>
             </li>
@@ -183,8 +183,8 @@ final class MenuTest extends TestCase
             <li><a href="/prod">Prod</a></li>
             <li><a aria-current="page" class="active" href="/products">Products</a></li>
             <li>
-            <a aria-expanded="false" data-bs-toggle="dropdown" role="button" href="/catalog">Catalog</a>
-            <ul>
+            <a aria-expanded="false" data-bs-toggle="dropdown" role="button" id="dropdown-1" href="/catalog">Catalog</a>
+            <ul aria-labelledby="dropdown-1">
             <li><a href="/phone">Phone</a></li>
             </ul>
             </li>

--- a/tests/Menu/MenuTest.php
+++ b/tests/Menu/MenuTest.php
@@ -166,6 +166,12 @@ final class MenuTest extends TestCase
             <ul>
             <li><a href="/prod">Prod</a></li>
             <li><a aria-current="page" class="active" href="/products">Products</a></li>
+            <li>
+            <a aria-expanded="false" data-bs-toggle="dropdown" role="button" href="/catalog">Catalog</a>
+            <ul>
+            <li><a href="/phone">Phone</a></li>
+            </ul>
+            </li>
             </ul>
             HTML,
             Menu::widget()
@@ -174,6 +180,13 @@ final class MenuTest extends TestCase
                 ->items([
                     ['label' => 'Prod', 'link' => '/prod'],
                     ['label' => 'Products', 'link' => '/products'],
+                    [
+                        'label' => 'Catalog',
+                        'link' => '/catalog',
+                        'items' => [
+                            ['label' => 'Phone', 'link' => '/phone'],
+                        ],
+                    ],
                 ])
                 ->render(),
         );

--- a/tests/Menu/MenuTest.php
+++ b/tests/Menu/MenuTest.php
@@ -55,20 +55,27 @@ final class MenuTest extends TestCase
             <<<HTML
             <ul>
             <li><a href="/">Home</a></li>
-            <li><a class="active-trail" href="/products">Products</a></li>
-            <li><a class="active-trail" href="/products/electronics">Electronics</a></li>
-            <li><a aria-current="page" class="active" href="/products/electronics/phones">Phones</a></li>
+            <li>
+            <a aria-expanded="false" data-bs-toggle="dropdown" role="button" class="active-trail" href="/catalog">Products</a>
+            <ul>
+            <li><a aria-current="page" class="active" href="/phones">Phones</a></li>
+            </ul>
+            </li>
             <li><a href="/about">About</a></li>
             </ul>
             HTML,
             Menu::widget()
                 ->activeTrail(true)
-                ->currentPath('/products/electronics/phones')
+                ->currentPath('/phones')
                 ->items([
                     ['label' => 'Home', 'link' => '/'],
-                    ['label' => 'Products', 'link' => '/products'],
-                    ['label' => 'Electronics', 'link' => '/products/electronics'],
-                    ['label' => 'Phones', 'link' => '/products/electronics/phones'],
+                    [
+                        'label' => 'Products',
+                        'link' => '/catalog',
+                        'items' => [
+                            ['label' => 'Phones', 'link' => '/phones'],
+                        ],
+                    ],
                     ['label' => 'About', 'link' => '/about'],
                 ])
                 ->render(),
@@ -80,17 +87,73 @@ final class MenuTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <ul>
-            <li><a class="trail" href="/products">Products</a></li>
-            <li><a aria-current="page" class="active" href="/products/phones">Phones</a></li>
+            <li>
+            <a aria-expanded="false" data-bs-toggle="dropdown" role="button" class="trail" href="/catalog">Products</a>
+            <ul>
+            <li><a aria-current="page" class="active" href="/phones">Phones</a></li>
+            </ul>
+            </li>
             </ul>
             HTML,
             Menu::widget()
                 ->activeTrail(true)
                 ->activeTrailClass('trail')
-                ->currentPath('/products/phones')
+                ->currentPath('/phones')
                 ->items([
-                    ['label' => 'Products', 'link' => '/products'],
-                    ['label' => 'Phones', 'link' => '/products/phones'],
+                    [
+                        'label' => 'Products',
+                        'link' => '/catalog',
+                        'items' => [
+                            ['label' => 'Phones', 'link' => '/phones'],
+                        ],
+                    ],
+                ])
+                ->render(),
+        );
+    }
+
+    public function testActiveTrailWithDropdownDefinitions(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <ul>
+            <li>
+            <a aria-expanded="false" data-bs-toggle="dropdown" role="button" class="dropdown-toggle active-trail" href="/catalog">Products</a>
+            <ul class="dropdown-menu">
+            <li><a class="dropdown-item active" aria-current="page" href="/phones">Phones</a></li>
+            </ul>
+            </li>
+            </ul>
+            HTML,
+            Menu::widget()
+                ->activeTrail(true)
+                ->currentPath('/phones')
+                ->dropdownDefinitions(
+                    [
+                        'container()' => [false],
+                        'dividerClass()' => ['dropdown-divider'],
+                        'headerClass()' => ['dropdown-header'],
+                        'itemClass()' => ['dropdown-item'],
+                        'itemsContainerClass()' => ['dropdown-menu'],
+                        'toggleAttributes()' => [
+                            [
+                                'aria-expanded' => 'false',
+                                'data-bs-toggle' => 'dropdown',
+                                'role' => 'button',
+                            ],
+                        ],
+                        'toggleClass()' => ['dropdown-toggle'],
+                        'toggleType()' => ['link'],
+                    ],
+                )
+                ->items([
+                    [
+                        'label' => 'Products',
+                        'link' => '/catalog',
+                        'items' => [
+                            ['label' => 'Phones', 'link' => '/phones'],
+                        ],
+                    ],
                 ])
                 ->render(),
         );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Docs added?   | ❌
| Tests added?  | ✔️
| Breaks BC?    | ❌

## What does this PR do?

Adds opt-in active trail support to `Menu`, so parent items can use a separate CSS class when a child item is active.

```php
Menu::widget()
    ->activeTrail(true)
    ->activeTrailClass('active-trail')
    ->currentPath('/phones')
    ->items([
        [
            'label' => 'Products',
            'link' => '/catalog',
            'items' => [
                ['label' => 'Phones', 'link' => '/phones'],
            ],
        ],
    ])
    ->render();
```

The active trail follows the menu item tree, not URL prefixes. Dropdown parent toggle attributes are prepared during menu normalization before rendering.

No BC break: the new behavior is disabled by default, and existing menu output is unchanged unless `activeTrail(true)` is set.