### PR TITLE
Add `submenu()` method to `Menu` for nested plain lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Bug #113: Fix `array_merge()` argument order in `Menu::renderItem()` so that item-level `linkAttributes` override widget-level ones (@WarLikeLaux)
 - Enh #114: Add `readonly` to constructor-promoted properties in `Block`, `ContentDecorator`, and `FragmentCache` (@WarLikeLaux)
 - Enh #123: Remove redundant `array_merge()` call with single argument in `Dropdown` (@WarLikeLaux)
+- New #137: Add `submenu()` method to `Menu` widget for rendering nested items as plain lists (@WarLikeLaux)
 
 ## 2.1.1 September 23, 2025
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Bug #118: Add missing ARIA attributes to `Dropdown`, `Menu`, and `Alert` (@WarLikeLaux)
 - Enh #155: Add `url` as alias for `link` in `Menu` and `Dropdown` items (@WarLikeLaux)
 - Enh #157: Improve psalm type annotations (@Tigrov)
+- Bug #137: Render raw string items in `Menu` instead of throwing `TypeError` (@WarLikeLaux)
 
 ## 2.1.1 September 23, 2025
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@
 - Bug #113: Fix `array_merge()` argument order in `Menu::renderItem()` so that item-level `linkAttributes` override widget-level ones (@WarLikeLaux)
 - Enh #114: Add `readonly` to constructor-promoted properties in `Block`, `ContentDecorator`, and `FragmentCache` (@WarLikeLaux)
 - Enh #123: Remove redundant `array_merge()` call with single argument in `Dropdown` (@WarLikeLaux)
-- New #137: Add `submenu()` method to `Menu` widget for rendering nested items as plain lists (@WarLikeLaux)
 - Enh #132: Remove raw keys from normalized items in `Normalizer::dropdown()` and `Normalizer::menu()` (@WarLikeLaux)
 - Bug #133: Fix `Alert::render()` returning empty string when body is empty but header is set (@WarLikeLaux)
 - New #126: Add `Menu::dropdownContainerAttributes()` method (@WarLikeLaux)
@@ -20,6 +19,7 @@
 - Bug #118: Add missing ARIA attributes to `Dropdown`, `Menu`, and `Alert` (@WarLikeLaux)
 - Enh #155: Add `url` as alias for `link` in `Menu` and `Dropdown` items (@WarLikeLaux)
 - Enh #157: Improve psalm type annotations (@Tigrov)
+- New #137: Add `submenu()` method to `Menu` widget for rendering nested items as plain lists (@WarLikeLaux)
 - Bug #137: Render raw string items in `Menu` instead of throwing `TypeError` (@WarLikeLaux)
 
 ## 2.1.1 September 23, 2025

--- a/src/Helper/Normalizer.php
+++ b/src/Helper/Normalizer.php
@@ -63,6 +63,7 @@ final class Normalizer
         string $currentPath,
         bool $activateItems,
         array $iconContainerAttributes = [],
+        bool $submenu = false,
     ): array {
         /**
          * @psalm-var array[] $items
@@ -76,7 +77,28 @@ final class Normalizer
                         $currentPath,
                         $activateItems,
                         $iconContainerAttributes,
+                        $submenu,
                     );
+
+                    if ($submenu) {
+                        $items[$i]['link'] = self::link($child);
+                        $items[$i]['linkAttributes'] = self::linkAttributes($child);
+                        $items[$i]['active'] = self::active(
+                            $child,
+                            $items[$i]['link'],
+                            $currentPath,
+                            $activateItems,
+                        );
+                        $items[$i]['disabled'] = self::disabled($child);
+                        $items[$i]['visible'] = self::visible($child);
+                        $items[$i]['label'] = self::renderLabel(
+                            self::label($child),
+                            self::icon($child),
+                            self::iconAttributes($child),
+                            self::iconClass($child),
+                            self::iconContainerAttributes($child, $iconContainerAttributes),
+                        );
+                    }
                 } else {
                     $items[$i]['link'] = self::link($child);
                     $items[$i]['linkAttributes'] = self::linkAttributes($child);

--- a/src/Helper/Normalizer.php
+++ b/src/Helper/Normalizer.php
@@ -107,6 +107,14 @@ final class Normalizer
                             self::iconClass($child),
                             self::iconContainerAttributes($child, $iconContainerAttributes),
                         );
+
+                        unset(
+                            $items[$i]['encode'],
+                            $items[$i]['icon'],
+                            $items[$i]['iconAttributes'],
+                            $items[$i]['iconClass'],
+                            $items[$i]['iconContainerAttributes'],
+                        );
                     }
                 } else {
                     $items[$i]['link'] = self::link($child);

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -70,6 +70,7 @@ final class Menu extends Widget
     private array $linkAttributes = [];
     private string $linkClass = '';
     private string $linkTag = 'a';
+    private bool $submenu = false;
     private string $tagName = 'ul';
     private string $template = '{items}';
 
@@ -468,6 +469,19 @@ final class Menu extends Widget
     }
 
     /**
+     * Returns a new instance with submenu rendering enabled or disabled.
+     *
+     * @param bool $value Whether to render sub-items as nested lists instead of Dropdown widgets.
+     */
+    public function submenu(bool $value): self
+    {
+        $new = clone $this;
+        $new->submenu = $value;
+
+        return $new;
+    }
+
+    /**
      * Returns a new instance with the specified tag for rendering the menu.
      *
      * @param string $value The tag for rendering the menu.
@@ -526,6 +540,7 @@ final class Menu extends Widget
             $this->currentPath,
             $this->activateItems,
             $this->iconContainerAttributes,
+            $this->submenu,
         );
 
         return $this->renderMenu($items);
@@ -665,8 +680,42 @@ final class Menu extends Widget
         $n = count($items);
 
         foreach ($items as $i => $item) {
-            if (isset($item['items'])) {
+            if (isset($item['items']) && !$this->submenu) {
                 $lines[] = strtr($this->template, ['{items}' => $this->renderDropdown([$item])]);
+            } elseif (isset($item['items'])) {
+                if ($item['visible']) {
+                    $parentLink = $this->renderItem($item);
+                    /** @psalm-suppress MixedArgumentTypeCoercion */
+                    $nestedItems = $this->renderItems($item['items']);
+
+                    if ($this->tagName === '') {
+                        throw new InvalidArgumentException('Tag name must be a string and cannot be empty.');
+                    }
+
+                    $nestedList = Html::normalTag($this->tagName, $nestedItems . PHP_EOL, [])
+                        ->encode(false)
+                        ->render();
+
+                    if ($this->itemsTag === '') {
+                        throw new InvalidArgumentException('Tag name must be a string and cannot be empty.');
+                    }
+
+                    $itemsContainerAttributes = array_merge(
+                        $this->itemsContainerAttributes,
+                        $item['itemsContainerAttributes'] ?? [],
+                    );
+
+                    $lines[] = match ($this->itemsContainer) {
+                        false => $parentLink . PHP_EOL . $nestedList,
+                        default => Html::normalTag(
+                            $this->itemsTag,
+                            $parentLink . PHP_EOL . $nestedList,
+                            $itemsContainerAttributes,
+                        )
+                            ->encode(false)
+                            ->render(),
+                    };
+                }
             } elseif ($item['visible']) {
                 $itemsContainerAttributes = array_merge(
                     $this->itemsContainerAttributes,

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -16,6 +16,7 @@ use Yiisoft\Widget\Widget;
 use function array_merge;
 use function count;
 use function implode;
+use function is_string;
 use function strtr;
 use function trim;
 
@@ -697,7 +698,7 @@ final class Menu extends Widget
      *
      * @psalm-param array<
      *   array-key,
-     *   array{
+     *   string|array{
      *     label: string,
      *     link: string,
      *     linkAttributes: array,
@@ -715,6 +716,12 @@ final class Menu extends Widget
         $n = count($items);
 
         foreach ($items as $i => $item) {
+            if (is_string($item)) {
+                $lines[] = $item;
+
+                continue;
+            }
+
             if (isset($item['items']) && !$this->submenu) {
                 $lines[] = strtr($this->template, ['{items}' => $this->renderDropdown([$item])]);
             } elseif (isset($item['items'])) {

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -741,14 +741,19 @@ final class Menu extends Widget
                     );
 
                     $lines[] = match ($this->itemsContainer) {
-                        false => $parentLink . PHP_EOL . $nestedList,
-                        default => Html::normalTag(
-                            $this->itemsTag,
-                            $parentLink . PHP_EOL . $nestedList,
-                            $itemsContainerAttributes,
-                        )
-                            ->encode(false)
-                            ->render(),
+                        false => strtr($this->template, ['{items}' => $parentLink . PHP_EOL . $nestedList]),
+                        default => strtr(
+                            $this->template,
+                            [
+                                '{items}' => Html::normalTag(
+                                    $this->itemsTag,
+                                    $parentLink . PHP_EOL . $nestedList,
+                                    $itemsContainerAttributes,
+                                )
+                                    ->encode(false)
+                                    ->render(),
+                            ],
+                        ),
                     };
                 }
             } elseif ($item['visible']) {

--- a/tests/Helper/NormalizerTest.php
+++ b/tests/Helper/NormalizerTest.php
@@ -58,6 +58,36 @@ final class NormalizerTest extends TestCase
         $this->assertArrayNotHasKey('iconContainerAttributes', $items[0]);
     }
 
+    public function testMenuRemovesRawKeysFromSubmenuParent(): void
+    {
+        $items = Normalizer::menu(
+            [
+                [
+                    'label' => 'Parent',
+                    'link' => '#',
+                    'encode' => false,
+                    'icon' => 'home',
+                    'iconAttributes' => ['class' => 'bi'],
+                    'iconClass' => 'bi-home',
+                    'iconContainerAttributes' => ['class' => 'icon'],
+                    'items' => [
+                        ['label' => 'Child', 'link' => '#child'],
+                    ],
+                ],
+            ],
+            '',
+            false,
+            [],
+            true,
+        );
+
+        $this->assertArrayNotHasKey('encode', $items[0]);
+        $this->assertArrayNotHasKey('icon', $items[0]);
+        $this->assertArrayNotHasKey('iconAttributes', $items[0]);
+        $this->assertArrayNotHasKey('iconClass', $items[0]);
+        $this->assertArrayNotHasKey('iconContainerAttributes', $items[0]);
+    }
+
     public function testRenderLabel(): void
     {
         $this->assertSame('test', Normalizer::renderLabel('test', '', [], '', []));

--- a/tests/Menu/ImmutableTest.php
+++ b/tests/Menu/ImmutableTest.php
@@ -44,6 +44,7 @@ final class ImmutableTest extends TestCase
         $this->assertNotSame($menu, $menu->linkAttributes([]));
         $this->assertNotSame($menu, $menu->linkClass(''));
         $this->assertNotSame($menu, $menu->linkTag(''));
+        $this->assertNotSame($menu, $menu->submenu(false));
         $this->assertNotSame($menu, $menu->tagName(''));
         $this->assertNotSame($menu, $menu->template(''));
     }

--- a/tests/Menu/MenuTest.php
+++ b/tests/Menu/MenuTest.php
@@ -687,6 +687,33 @@ final class MenuTest extends TestCase
             ->render();
     }
 
+    public function testSubmenuWithItemsContainerFalse(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <ul>
+            <a href="/products">Products</a>
+            <ul>
+            <a href="/products/electronics">Electronics</a>
+            </ul>
+            </ul>
+            HTML,
+            Menu::widget()
+                ->submenu(true)
+                ->itemsContainer(false)
+                ->items([
+                    [
+                        'label' => 'Products',
+                        'link' => '/products',
+                        'items' => [
+                            ['label' => 'Electronics', 'link' => '/products/electronics'],
+                        ],
+                    ],
+                ])
+                ->render(),
+        );
+    }
+
     public function testSubmenuWithActiveItems(): void
     {
         Assert::equalsWithoutLE(

--- a/tests/Menu/MenuTest.php
+++ b/tests/Menu/MenuTest.php
@@ -9,6 +9,7 @@ use Stringable;
 use Yiisoft\Yii\Widgets\Menu;
 use Yiisoft\Yii\Widgets\Tests\Support\Assert;
 use Yiisoft\Yii\Widgets\Tests\Support\TestTrait;
+use InvalidArgumentException;
 
 final class MenuTest extends TestCase
 {
@@ -622,6 +623,97 @@ final class MenuTest extends TestCase
     public function testRender(): void
     {
         $this->assertEmpty(Menu::widget()->render());
+    }
+
+    public function testSubmenu(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <ul>
+            <li><a href="/products">Products</a>
+            <ul>
+            <li><a href="/products/electronics">Electronics</a></li>
+            <li><a href="/products/books">Books</a></li>
+            </ul></li>
+            </ul>
+            HTML,
+            Menu::widget()
+                ->submenu(true)
+                ->items([
+                    [
+                        'label' => 'Products',
+                        'link' => '/products',
+                        'items' => [
+                            ['label' => 'Electronics', 'link' => '/products/electronics'],
+                            ['label' => 'Books', 'link' => '/products/books'],
+                        ],
+                    ],
+                ])
+                ->render(),
+        );
+    }
+
+    public function testSubmenuWithEmptyItemsTag(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        Menu::widget()
+            ->submenu(true)
+            ->itemsTag('')
+            ->items([
+                [
+                    'label' => 'Products',
+                    'link' => '/products',
+                    'items' => [],
+                ],
+            ])
+            ->render();
+    }
+
+    public function testSubmenuWithEmptyTagName(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        Menu::widget()
+            ->submenu(true)
+            ->tagName('')
+            ->items([
+                [
+                    'label' => 'Products',
+                    'link' => '/products',
+                    'items' => [['label' => 'A', 'link' => '/a']],
+                ],
+            ])
+            ->render();
+    }
+
+    public function testSubmenuWithActiveItems(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <ul>
+            <li><a href="/products">Products</a>
+            <ul>
+            <li><a aria-current="page" class="active" href="/products/electronics">Electronics</a></li>
+            <li><a href="/products/books">Books</a></li>
+            </ul></li>
+            </ul>
+            HTML,
+            Menu::widget()
+                ->submenu(true)
+                ->currentPath('/products/electronics')
+                ->items([
+                    [
+                        'label' => 'Products',
+                        'link' => '/products',
+                        'items' => [
+                            ['label' => 'Electronics', 'link' => '/products/electronics'],
+                            ['label' => 'Books', 'link' => '/products/books'],
+                        ],
+                    ],
+                ])
+                ->render(),
+        );
     }
 
     public function testTemplate(): void

--- a/tests/Menu/MenuTest.php
+++ b/tests/Menu/MenuTest.php
@@ -852,6 +852,36 @@ final class MenuTest extends TestCase
         );
     }
 
+    public function testSubmenuWithStringItem(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <ul>
+            <li><a href="/products">Products</a>
+            <ul>
+            <li><a href="/products/electronics">Electronics</a></li>
+            -
+            <li><a href="/products/books">Books</a></li>
+            </ul></li>
+            </ul>
+            HTML,
+            Menu::widget()
+                ->submenu(true)
+                ->items([
+                    [
+                        'label' => 'Products',
+                        'link' => '/products',
+                        'items' => [
+                            ['label' => 'Electronics', 'link' => '/products/electronics'],
+                            '-',
+                            ['label' => 'Books', 'link' => '/products/books'],
+                        ],
+                    ],
+                ])
+                ->render(),
+        );
+    }
+
     public function testTemplate(): void
     {
         Assert::equalsWithoutLE(

--- a/tests/Menu/MenuTest.php
+++ b/tests/Menu/MenuTest.php
@@ -795,6 +795,63 @@ final class MenuTest extends TestCase
         );
     }
 
+    public function testSubmenuWithTemplate(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <ul>
+            <div class="test-class"><li><a href="/products">Products</a>
+            <ul>
+            <div class="test-class"><li><a href="/products/electronics">Electronics</a></li></div>
+            <div class="test-class"><li><a href="/products/books">Books</a></li></div>
+            </ul></li></div>
+            </ul>
+            HTML,
+            Menu::widget()
+                ->submenu(true)
+                ->template('<div class="test-class">{items}</div>')
+                ->items([
+                    [
+                        'label' => 'Products',
+                        'link' => '/products',
+                        'items' => [
+                            ['label' => 'Electronics', 'link' => '/products/electronics'],
+                            ['label' => 'Books', 'link' => '/products/books'],
+                        ],
+                    ],
+                ])
+                ->render(),
+        );
+    }
+
+    public function testSubmenuWithTemplateAndItemsContainerFalse(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <ul>
+            <div class="test-class"><a href="/products">Products</a>
+            <ul>
+            <a href="/products/electronics">Electronics</a>
+            </ul></div>
+            </ul>
+            HTML,
+            Menu::widget()
+                ->submenu(true)
+                ->itemsContainer(false)
+                ->template('<div class="test-class">{items}</div>')
+                ->items([
+                    [
+                        'label' => 'Products',
+                        'link' => '/products',
+                        'items' => [
+                            ['label' => 'Electronics', 'link' => '/products/electronics'],
+                        ],
+                    ],
+                ])
+                ->render(),
+        );
+    }
+
     public function testTemplate(): void
     {
         Assert::equalsWithoutLE(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Docs added?   | ❌
| Tests added?  | ✔️
| Breaks BC?    | ❌

## What does this PR do?

Add `submenu()` method to `Menu`. When `submenu(true)` is set, items with sub-items render as nested `<ul>`/`<li>` lists instead of delegating to `Dropdown::widget()`.

Currently, all items with sub-items go through Dropdown, which adds toggle buttons, `data-bs-toggle`, and dropdown-specific markup. This makes Menu unusable for sidebar navigation, sitemaps, or tree menus that need plain nested lists.

With `submenu(true)`, parent items render their own link via `renderItem()`, and sub-items are rendered recursively through `renderItems()`. `Normalizer::menu()` also normalizes parent items (label, link, active, etc.) when `$submenu` is true.

It also fixes a `TypeError` when menu items contain raw string entries like `-`. Such strings now render directly, matching the documented `items()` behavior.

No BC break: `submenu` defaults to `false`, preserving current Dropdown behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `submenu()` method enabling the Menu widget to render nested items as plain HTML lists instead of dropdown widgets.
  * Parent menu items now receive proper normalization when containing nested items.

* **Tests**
  * Added comprehensive test coverage for submenu rendering, including nested item normalization, active state propagation, and template handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yiisoft/yii-widgets/pull/137?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->