### PR TITLE
Add badge support to `Menu` and `Dropdown`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Bug #113: Fix `array_merge()` argument order in `Menu::renderItem()` so that item-level `linkAttributes` override widget-level ones (@WarLikeLaux)
 - Enh #114: Add `readonly` to constructor-promoted properties in `Block`, `ContentDecorator`, and `FragmentCache` (@WarLikeLaux)
 - Enh #123: Remove redundant `array_merge()` call with single argument in `Dropdown` (@WarLikeLaux)
+- New #138: Add badge support to `Menu` and `Dropdown` widgets (@WarLikeLaux)
 
 ## 2.1.1 September 23, 2025
 

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -25,6 +25,9 @@ use const PHP_EOL;
 final class Dropdown extends Widget
 {
     private string $activeClass = 'active';
+    private array $badgeAttributes = [];
+    private string $badgeClass = '';
+    private string $badgeTag = 'span';
     private bool $container = true;
     private array $containerAttributes = [];
     private string $containerClass = '';
@@ -58,6 +61,45 @@ final class Dropdown extends Widget
     {
         $new = clone $this;
         $new->activeClass = $value;
+
+        return $new;
+    }
+
+    /**
+     * Returns a new instance with the specified badge HTML attributes.
+     *
+     * @param array $valuesMap Attribute values indexed by attribute names.
+     */
+    public function badgeAttributes(array $valuesMap): self
+    {
+        $new = clone $this;
+        $new->badgeAttributes = $valuesMap;
+
+        return $new;
+    }
+
+    /**
+     * Returns a new instance with the specified badge CSS class.
+     *
+     * @param string $value The badge CSS class.
+     */
+    public function badgeClass(string $value): self
+    {
+        $new = clone $this;
+        $new->badgeClass = $value;
+
+        return $new;
+    }
+
+    /**
+     * Returns a new instance with the specified badge tag.
+     *
+     * @param string $value The badge tag.
+     */
+    public function badgeTag(string $value): self
+    {
+        $new = clone $this;
+        $new->badgeTag = $value;
 
         return $new;
     }
@@ -452,7 +494,12 @@ final class Dropdown extends Widget
          *   }|string
          * > $normalizedItems
          */
-        $normalizedItems = Helper\Normalizer::dropdown($this->items);
+        $normalizedItems = Helper\Normalizer::dropdown(
+            $this->items,
+            $this->badgeAttributes,
+            $this->badgeClass,
+            $this->badgeTag,
+        );
 
         $containerAttributes = $this->containerAttributes;
 
@@ -499,6 +546,9 @@ final class Dropdown extends Widget
     private function renderDropdown(array $items): string
     {
         return self::widget()
+            ->badgeAttributes($this->badgeAttributes)
+            ->badgeClass($this->badgeClass)
+            ->badgeTag($this->badgeTag)
             ->container(false)
             ->dividerAttributes($this->dividerAttributes)
             ->headerClass($this->headerClass)

--- a/src/Helper/Normalizer.php
+++ b/src/Helper/Normalizer.php
@@ -19,8 +19,12 @@ final class Normalizer
     /**
      * Normalize the given array of items for the dropdown.
      */
-    public static function dropdown(array $items): array
-    {
+    public static function dropdown(
+        array $items,
+        array $badgeAttributes = [],
+        string $badgeClass = '',
+        string $badgeTag = 'span',
+    ): array {
         /**
          * @psalm-var array[] $items
          * @psalm-suppress RedundantConditionGivenDocblockType
@@ -33,6 +37,10 @@ final class Normalizer
                     self::iconAttributes($child),
                     self::iconClass($child),
                     self::iconContainerAttributes($child),
+                    self::badge($child),
+                    self::badgeAttributes($child, $badgeAttributes),
+                    $badgeClass,
+                    $badgeTag,
                 );
                 $items[$i]['active'] = self::active($child, '', '', false);
                 $items[$i]['disabled'] = self::disabled($child);
@@ -45,7 +53,7 @@ final class Normalizer
                 $items[$i]['visible'] = self::visible($child);
 
                 if (isset($child['items']) && is_array($child['items'])) {
-                    $items[$i]['items'] = self::dropdown($child['items']);
+                    $items[$i]['items'] = self::dropdown($child['items'], $badgeAttributes, $badgeClass, $badgeTag);
                 } else {
                     $items[$i]['items'] = [];
                 }
@@ -63,6 +71,9 @@ final class Normalizer
         string $currentPath,
         bool $activateItems,
         array $iconContainerAttributes = [],
+        array $badgeAttributes = [],
+        string $badgeClass = '',
+        string $badgeTag = 'span',
     ): array {
         /**
          * @psalm-var array[] $items
@@ -76,6 +87,9 @@ final class Normalizer
                         $currentPath,
                         $activateItems,
                         $iconContainerAttributes,
+                        $badgeAttributes,
+                        $badgeClass,
+                        $badgeTag,
                     );
                 } else {
                     $items[$i]['link'] = self::link($child);
@@ -94,6 +108,10 @@ final class Normalizer
                         self::iconAttributes($child),
                         self::iconClass($child),
                         self::iconContainerAttributes($child, $iconContainerAttributes),
+                        self::badge($child),
+                        self::badgeAttributes($child, $badgeAttributes),
+                        $badgeClass,
+                        $badgeTag,
                     );
                 }
             }
@@ -108,6 +126,10 @@ final class Normalizer
         array $iconAttributes,
         string $iconClass,
         array $iconContainerAttributes,
+        string $badge = '',
+        array $badgeAttributes = [],
+        string $badgeClass = '',
+        string $badgeTag = 'span',
     ): string {
         $html = '';
 
@@ -124,7 +146,26 @@ final class Normalizer
             $html .= $label;
         }
 
+        if ($badge !== '' && $badgeTag !== '') {
+            if ($badgeClass !== '') {
+                Html::addCssClass($badgeAttributes, $badgeClass);
+            }
+
+            $html .= ' ' . Html::normalTag($badgeTag, $badge, $badgeAttributes)->encode(false)->render();
+        }
+
         return $html;
+    }
+
+    private static function badge(array $item): string
+    {
+        return array_key_exists('badge', $item) && is_string($item['badge']) ? $item['badge'] : '';
+    }
+
+    private static function badgeAttributes(array $item, array $defaultAttributes = []): array
+    {
+        return array_key_exists('badgeAttributes', $item) && is_array($item['badgeAttributes'])
+            ? $item['badgeAttributes'] : $defaultAttributes;
     }
 
     private static function active(array $item, string $link, string $currentPath, bool $activateItems): bool

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -50,6 +50,9 @@ final class Menu extends Widget
     private string $activeClass = 'active';
     private bool $activateItems = true;
     private array $attributes = [];
+    private array $badgeAttributes = [];
+    private string $badgeClass = '';
+    private string $badgeTag = 'span';
     private array $beforeAttributes = [];
     private string $beforeContent = '';
     private string $beforeTag = 'span';
@@ -161,6 +164,45 @@ final class Menu extends Widget
     {
         $new = clone $this;
         $new->attributes = $valuesMap;
+
+        return $new;
+    }
+
+    /**
+     * Returns a new instance with the specified badge HTML attributes.
+     *
+     * @param array $valuesMap Attribute values indexed by attribute names.
+     */
+    public function badgeAttributes(array $valuesMap): self
+    {
+        $new = clone $this;
+        $new->badgeAttributes = $valuesMap;
+
+        return $new;
+    }
+
+    /**
+     * Returns a new instance with the specified badge CSS class.
+     *
+     * @param string $value The badge CSS class.
+     */
+    public function badgeClass(string $value): self
+    {
+        $new = clone $this;
+        $new->badgeClass = $value;
+
+        return $new;
+    }
+
+    /**
+     * Returns a new instance with the specified badge tag.
+     *
+     * @param string $value The badge tag.
+     */
+    public function badgeTag(string $value): self
+    {
+        $new = clone $this;
+        $new->badgeTag = $value;
 
         return $new;
     }
@@ -526,6 +568,9 @@ final class Menu extends Widget
             $this->currentPath,
             $this->activateItems,
             $this->iconContainerAttributes,
+            $this->badgeAttributes,
+            $this->badgeClass,
+            $this->badgeTag,
         );
 
         return $this->renderMenu($items);

--- a/tests/Dropdown/DropdownTest.php
+++ b/tests/Dropdown/DropdownTest.php
@@ -37,6 +37,23 @@ final class DropdownTest extends TestCase
         );
     }
 
+    public function testBadge(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <div>
+            <li><a href="#">Inbox <span class="badge">5</span></a></li>
+            </div>
+            HTML,
+            Dropdown::widget()
+                ->badgeClass('badge')
+                ->items([
+                    ['label' => 'Inbox', 'link' => '#', 'badge' => '5'],
+                ])
+                ->render(),
+        );
+    }
+
     public function testContainerAttributes(): void
     {
         Assert::equalsWithoutLE(

--- a/tests/Dropdown/ImmutableTest.php
+++ b/tests/Dropdown/ImmutableTest.php
@@ -16,6 +16,9 @@ final class ImmutableTest extends TestCase
     {
         $dropdown = Dropdown::widget();
         $this->assertNotSame($dropdown, $dropdown->activeClass(''));
+        $this->assertNotSame($dropdown, $dropdown->badgeAttributes([]));
+        $this->assertNotSame($dropdown, $dropdown->badgeClass(''));
+        $this->assertNotSame($dropdown, $dropdown->badgeTag('span'));
         $this->assertNotSame($dropdown, $dropdown->container(false));
         $this->assertNotSame($dropdown, $dropdown->containerAttributes([]));
         $this->assertNotSame($dropdown, $dropdown->containerClass(''));

--- a/tests/Menu/ImmutableTest.php
+++ b/tests/Menu/ImmutableTest.php
@@ -22,6 +22,9 @@ final class ImmutableTest extends TestCase
         $this->assertNotSame($menu, $menu->afterTag(''));
         $this->assertNotSame($menu, $menu->activeClass(''));
         $this->assertNotSame($menu, $menu->attributes([]));
+        $this->assertNotSame($menu, $menu->badgeAttributes([]));
+        $this->assertNotSame($menu, $menu->badgeClass(''));
+        $this->assertNotSame($menu, $menu->badgeTag('span'));
         $this->assertNotSame($menu, $menu->beforeAttributes([]));
         $this->assertNotSame($menu, $menu->beforeClass(''));
         $this->assertNotSame($menu, $menu->beforeContent(''));

--- a/tests/Menu/MenuTest.php
+++ b/tests/Menu/MenuTest.php
@@ -36,6 +36,42 @@ final class MenuTest extends TestCase
         );
     }
 
+    public function testBadge(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <ul>
+            <li><a href="/inbox">Inbox <span class="badge">5</span></a></li>
+            <li><a href="/settings">Settings</a></li>
+            </ul>
+            HTML,
+            Menu::widget()
+                ->badgeClass('badge')
+                ->items([
+                    ['label' => 'Inbox', 'link' => '/inbox', 'badge' => '5'],
+                    ['label' => 'Settings', 'link' => '/settings'],
+                ])
+                ->render(),
+        );
+    }
+
+    public function testBadgeWithItemAttributes(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <ul>
+            <li><a href="/inbox">Inbox <span class="badge-custom badge-default">3</span></a></li>
+            </ul>
+            HTML,
+            Menu::widget()
+                ->badgeClass('badge-default')
+                ->items([
+                    ['label' => 'Inbox', 'link' => '/inbox', 'badge' => '3', 'badgeAttributes' => ['class' => 'badge-custom']],
+                ])
+                ->render(),
+        );
+    }
+
     public function testActiveItemsWithFalse(): void
     {
         Assert::equalsWithoutLE(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Docs added?   | ❌
| Tests added?  | ✔️
| Breaks BC?    | ❌

## What does this PR do?

Add badge support to `Menu` and `Dropdown`. Items can include a `badge` key with text that renders as a `<span>` (or configurable tag) after the label.

Widget-level methods: `badgeAttributes()`, `badgeClass()`, `badgeTag()`. Item-level keys: `badge` (text), `badgeAttributes` (override). Badge rendering is handled in `Normalizer::renderLabel()` following the same pattern as icon rendering.

No BC break: new optional keys and methods only.
