### PR TITLE
Add `emptyText()` to `Menu` and `Dropdown`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Bug #113: Fix `array_merge()` argument order in `Menu::renderItem()` so that item-level `linkAttributes` override widget-level ones (@WarLikeLaux)
 - Enh #114: Add `readonly` to constructor-promoted properties in `Block`, `ContentDecorator`, and `FragmentCache` (@WarLikeLaux)
 - Enh #123: Remove redundant `array_merge()` call with single argument in `Dropdown` (@WarLikeLaux)
+- New #139: Add `emptyText()` method to `Menu` and `Dropdown` widgets (@WarLikeLaux)
 
 ## 2.1.1 September 23, 2025
 

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -30,6 +30,9 @@ final class Dropdown extends Widget
     private string $containerClass = '';
     private string $containerTag = 'div';
     private string $disabledClass = 'disabled';
+    private string $emptyText = '';
+    private array $emptyTextAttributes = [];
+    private string $emptyTextTag = 'li';
     private array $dividerAttributes = [];
     private string $dividerClass = 'dropdown-divider';
     private string $dividerTag = 'hr';
@@ -122,6 +125,45 @@ final class Dropdown extends Widget
     {
         $new = clone $this;
         $new->disabledClass = $value;
+
+        return $new;
+    }
+
+    /**
+     * Returns a new instance with the specified empty text.
+     *
+     * @param string $value The text to display when there are no visible items.
+     */
+    public function emptyText(string $value): self
+    {
+        $new = clone $this;
+        $new->emptyText = $value;
+
+        return $new;
+    }
+
+    /**
+     * Returns a new instance with the specified empty text HTML attributes.
+     *
+     * @param array $valuesMap Attribute values indexed by attribute names.
+     */
+    public function emptyTextAttributes(array $valuesMap): self
+    {
+        $new = clone $this;
+        $new->emptyTextAttributes = $valuesMap;
+
+        return $new;
+    }
+
+    /**
+     * Returns a new instance with the specified empty text tag.
+     *
+     * @param string $value The tag for the empty text element.
+     */
+    public function emptyTextTag(string $value): self
+    {
+        $new = clone $this;
+        $new->emptyTextTag = $value;
 
         return $new;
     }
@@ -459,7 +501,19 @@ final class Dropdown extends Widget
         $items = $this->renderItems($normalizedItems) . PHP_EOL;
 
         if (trim($items) === '') {
-            return '';
+            if ($this->emptyText === '') {
+                return '';
+            }
+
+            if ($this->emptyTextTag === '') {
+                throw new InvalidArgumentException('Tag name must be a string and cannot be empty.');
+            }
+
+            $items = PHP_EOL
+                . Html::normalTag($this->emptyTextTag, $this->emptyText, $this->emptyTextAttributes)
+                    ->encode(false)
+                    ->render()
+                . PHP_EOL;
         }
 
         if ($this->containerClass !== '') {

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -56,6 +56,9 @@ final class Menu extends Widget
     private bool $container = true;
     private string $currentPath = '';
     private string $disabledClass = 'disabled';
+    private string $emptyText = '';
+    private array $emptyTextAttributes = [];
+    private string $emptyTextTag = 'li';
     private bool $dropdownContainer = true;
     private array $dropdownContainerAttributes = [];
     private string $dropdownContainerTag = 'li';
@@ -265,6 +268,45 @@ final class Menu extends Widget
     {
         $new = clone $this;
         $new->disabledClass = $value;
+
+        return $new;
+    }
+
+    /**
+     * Returns a new instance with the specified empty text.
+     *
+     * @param string $value The text to display when there are no visible items.
+     */
+    public function emptyText(string $value): self
+    {
+        $new = clone $this;
+        $new->emptyText = $value;
+
+        return $new;
+    }
+
+    /**
+     * Returns a new instance with the specified empty text HTML attributes.
+     *
+     * @param array $valuesMap Attribute values indexed by attribute names.
+     */
+    public function emptyTextAttributes(array $valuesMap): self
+    {
+        $new = clone $this;
+        $new->emptyTextAttributes = $valuesMap;
+
+        return $new;
+    }
+
+    /**
+     * Returns a new instance with the specified empty text tag.
+     *
+     * @param string $value The tag for the empty text element.
+     */
+    public function emptyTextTag(string $value): self
+    {
+        $new = clone $this;
+        $new->emptyTextTag = $value;
 
         return $new;
     }
@@ -504,6 +546,10 @@ final class Menu extends Widget
     public function render(): string
     {
         if ($this->items === []) {
+            if ($this->emptyText !== '') {
+                return $this->renderMenu([]);
+            }
+
             return '';
         }
 
@@ -727,6 +773,14 @@ final class Menu extends Widget
         $beforeContent = '';
 
         $content = $this->renderItems($items) . PHP_EOL;
+
+        if (trim($content) === '' && $this->emptyText !== '' && $this->emptyTextTag !== '') {
+            $content = PHP_EOL
+                . Html::normalTag($this->emptyTextTag, $this->emptyText, $this->emptyTextAttributes)
+                    ->encode(false)
+                    ->render()
+                . PHP_EOL;
+        }
 
         if ($this->beforeContent !== '') {
             $beforeContent = $this->renderBeforeContent() . PHP_EOL;

--- a/tests/Dropdown/DropdownTest.php
+++ b/tests/Dropdown/DropdownTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\TestCase;
 use Yiisoft\Yii\Widgets\Dropdown;
 use Yiisoft\Yii\Widgets\Tests\Support\Assert;
 use Yiisoft\Yii\Widgets\Tests\Support\TestTrait;
+use InvalidArgumentException;
 
 final class DropdownTest extends TestCase
 {
@@ -99,6 +100,37 @@ final class DropdownTest extends TestCase
             HTML,
             Dropdown::widget()->disabledClass('test-disabled-class')->items($this->items)->render(),
         );
+    }
+
+    public function testEmptyText(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <div>
+            <li class="text-muted">No actions</li>
+            </div>
+            HTML,
+            Dropdown::widget()
+                ->emptyText('No actions')
+                ->emptyTextAttributes(['class' => 'text-muted'])
+                ->items([
+                    ['label' => 'Hidden', 'link' => '#', 'visible' => false],
+                ])
+                ->render(),
+        );
+    }
+
+    public function testEmptyTextTagEmpty(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        Dropdown::widget()
+            ->emptyText('No actions')
+            ->emptyTextTag('')
+            ->items([
+                ['label' => 'Hidden', 'link' => '#', 'visible' => false],
+            ])
+            ->render();
     }
 
     public function testDividerTag(): void

--- a/tests/Dropdown/ImmutableTest.php
+++ b/tests/Dropdown/ImmutableTest.php
@@ -21,6 +21,9 @@ final class ImmutableTest extends TestCase
         $this->assertNotSame($dropdown, $dropdown->containerClass(''));
         $this->assertNotSame($dropdown, $dropdown->containerTag(''));
         $this->assertNotSame($dropdown, $dropdown->disabledClass(''));
+        $this->assertNotSame($dropdown, $dropdown->emptyText(''));
+        $this->assertNotSame($dropdown, $dropdown->emptyTextAttributes([]));
+        $this->assertNotSame($dropdown, $dropdown->emptyTextTag('li'));
         $this->assertNotSame($dropdown, $dropdown->dividerAttributes([]));
         $this->assertNotSame($dropdown, $dropdown->dividerClass(''));
         $this->assertNotSame($dropdown, $dropdown->dividerTag(''));

--- a/tests/Menu/ImmutableTest.php
+++ b/tests/Menu/ImmutableTest.php
@@ -30,6 +30,9 @@ final class ImmutableTest extends TestCase
         $this->assertNotSame($menu, $menu->container(false));
         $this->assertNotSame($menu, $menu->currentPath(''));
         $this->assertNotSame($menu, $menu->disabledClass(''));
+        $this->assertNotSame($menu, $menu->emptyText(''));
+        $this->assertNotSame($menu, $menu->emptyTextAttributes([]));
+        $this->assertNotSame($menu, $menu->emptyTextTag('li'));
         $this->assertNotSame($menu, $menu->dropdownContainerClass(''));
         $this->assertNotSame($menu, $menu->dropdownContainerTag('div'));
         $this->assertNotSame($menu, $menu->dropdownDefinitions([]));

--- a/tests/Menu/MenuTest.php
+++ b/tests/Menu/MenuTest.php
@@ -185,6 +185,54 @@ final class MenuTest extends TestCase
         );
     }
 
+    public function testEmptyText(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <ul>
+            <li class="text-muted">No pages available</li>
+            </ul>
+            HTML,
+            Menu::widget()
+                ->emptyText('No pages available')
+                ->emptyTextAttributes(['class' => 'text-muted'])
+                ->items([])
+                ->render(),
+        );
+    }
+
+    public function testEmptyTextWithAllItemsInvisible(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <ul>
+            <li>Empty</li>
+            </ul>
+            HTML,
+            Menu::widget()
+                ->emptyText('Empty')
+                ->items([
+                    ['label' => 'Hidden', 'link' => '#', 'visible' => false],
+                ])
+                ->render(),
+        );
+    }
+
+    public function testEmptyTextNotShownWhenItemsExist(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <ul>
+            <li><a href="/path">item</a></li>
+            </ul>
+            HTML,
+            Menu::widget()
+                ->emptyText('Empty')
+                ->items($this->items)
+                ->render(),
+        );
+    }
+
     public function testDropdown(): void
     {
         Assert::equalsWithoutLE(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Docs added?   | ❌
| Tests added?  | ✔️
| Breaks BC?    | ❌

## What does this PR do?

Add `emptyText()` to `Menu` and `Dropdown`. When all items are invisible (or the items array is empty) and `emptyText` is set, the widget renders a container with the empty text instead of returning `''`.

New methods: `emptyText()`, `emptyTextAttributes()`, `emptyTextTag()`.

No BC break: `emptyText` defaults to `''`, preserving current behavior (return empty string).
