### PR TITLE
Add `Breadcrumbs::fromMenu()` and `Menu::activeTrail()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Bug #113: Fix `array_merge()` argument order in `Menu::renderItem()` so that item-level `linkAttributes` override widget-level ones (@WarLikeLaux)
 - Enh #114: Add `readonly` to constructor-promoted properties in `Block`, `ContentDecorator`, and `FragmentCache` (@WarLikeLaux)
 - Enh #123: Remove redundant `array_merge()` call with single argument in `Dropdown` (@WarLikeLaux)
+- New #140: Add `Breadcrumbs::fromMenu()` to auto-generate breadcrumbs from `Menu` active trail (@WarLikeLaux)
 
 ## 2.1.1 September 23, 2025
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@
 - Bug #113: Fix `array_merge()` argument order in `Menu::renderItem()` so that item-level `linkAttributes` override widget-level ones (@WarLikeLaux)
 - Enh #114: Add `readonly` to constructor-promoted properties in `Block`, `ContentDecorator`, and `FragmentCache` (@WarLikeLaux)
 - Enh #123: Remove redundant `array_merge()` call with single argument in `Dropdown` (@WarLikeLaux)
-- New #140: Add `Breadcrumbs::fromMenu()` to auto-generate breadcrumbs from `Menu` active trail (@WarLikeLaux)
 - Enh #132: Remove raw keys from normalized items in `Normalizer::dropdown()` and `Normalizer::menu()` (@WarLikeLaux)
 - Bug #133: Fix `Alert::render()` returning empty string when body is empty but header is set (@WarLikeLaux)
 - New #126: Add `Menu::dropdownContainerAttributes()` method (@WarLikeLaux)
@@ -20,6 +19,7 @@
 - Bug #118: Add missing ARIA attributes to `Dropdown`, `Menu`, and `Alert` (@WarLikeLaux)
 - Enh #155: Add `url` as alias for `link` in `Menu` and `Dropdown` items (@WarLikeLaux)
 - Enh #157: Improve psalm type annotations (@Tigrov)
+- New #140: Add `Breadcrumbs::fromMenu()` to auto-generate breadcrumbs from `Menu` active trail (@WarLikeLaux)
 
 ## 2.1.1 September 23, 2025
 

--- a/src/Breadcrumbs.php
+++ b/src/Breadcrumbs.php
@@ -87,6 +87,19 @@ final class Breadcrumbs extends Widget
     }
 
     /**
+     * Creates a new Breadcrumbs instance from a Menu widget's active trail.
+     *
+     * Walks the menu items tree, finds the active item, and builds breadcrumbs
+     * from the chain of ancestors. The returned instance can be further configured.
+     *
+     * @param Menu $menu The menu widget to extract breadcrumbs from.
+     */
+    public static function fromMenu(Menu $menu): self
+    {
+        return self::widget()->items($menu->activeTrail());
+    }
+
+    /**
      * Returns a new instance with the specified first item in the breadcrumbs (called home link).
      *
      * If a null is specified, the home item will not be rendered.

--- a/src/Helper/Normalizer.php
+++ b/src/Helper/Normalizer.php
@@ -17,6 +17,45 @@ use function is_string;
 final class Normalizer
 {
     /**
+     * Finds the active trail in a menu items tree and returns it as breadcrumb items.
+     *
+     * Walks the tree recursively, finds the active item by matching the current path
+     * or explicit `active` flag, and returns the chain of ancestors as breadcrumb-compatible items.
+     *
+     * @return array The active trail. Each element is an array with 'label' and optionally 'url' and 'encode' keys.
+     */
+    public static function activeTrail(array $items, string $currentPath, bool $activateItems): array
+    {
+        foreach ($items as $item) {
+            if (!is_array($item)) {
+                continue;
+            }
+
+            if (isset($item['visible']) && $item['visible'] === false) {
+                continue;
+            }
+
+            if (isset($item['items']) && is_array($item['items'])) {
+                $trail = self::activeTrail($item['items'], $currentPath, $activateItems);
+
+                if ($trail !== []) {
+                    return [self::breadcrumbItem($item, false), ...$trail];
+                }
+
+                continue;
+            }
+
+            $link = self::link($item);
+
+            if (self::active($item, $link, $currentPath, $activateItems)) {
+                return [self::breadcrumbItem($item, true)];
+            }
+        }
+
+        return [];
+    }
+
+    /**
      * Normalize the given array of items for the dropdown.
      */
     public static function dropdown(array $items): array
@@ -134,6 +173,36 @@ final class Normalizer
         }
 
         return is_bool($item['active']) ? $item['active'] : false;
+    }
+
+    /**
+     * Converts a menu item to a breadcrumb item.
+     */
+    private static function breadcrumbItem(array $item, bool $isActive): array
+    {
+        if (!isset($item['label'])) {
+            throw new InvalidArgumentException('The "label" option is required.');
+        }
+
+        if (!is_string($item['label'])) {
+            throw new InvalidArgumentException('The "label" option must be a string.');
+        }
+
+        $result = ['label' => $item['label']];
+
+        if (!$isActive) {
+            $link = self::link($item);
+
+            if ($link !== '') {
+                $result['url'] = $link;
+            }
+        }
+
+        if (isset($item['encode']) && $item['encode'] === false) {
+            $result['encode'] = false;
+        }
+
+        return $result;
     }
 
     private static function disabled(array $item): bool

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -495,6 +495,21 @@ final class Menu extends Widget
     }
 
     /**
+     * Returns the active trail as an array of breadcrumb items.
+     *
+     * Walks the items tree, finds the active item by matching the current path,
+     * and returns the chain of ancestors as breadcrumb-compatible items.
+     *
+     * @return array The active trail. Each element is an array with 'label' and optionally 'url' and 'encode' keys.
+     *
+     * @see Breadcrumbs::fromMenu()
+     */
+    public function activeTrail(): array
+    {
+        return Helper\Normalizer::activeTrail($this->items, $this->currentPath, $this->activateItems);
+    }
+
+    /**
      * Renders the menu.
      *
      * @throws CircularReferenceException|InvalidConfigException|NotFoundException|NotInstantiableException

--- a/tests/Breadcrumbs/BreadcrumbsTest.php
+++ b/tests/Breadcrumbs/BreadcrumbsTest.php
@@ -6,6 +6,7 @@ namespace Yiisoft\Yii\Widgets\Tests\Breadcrumbs;
 
 use PHPUnit\Framework\TestCase;
 use Yiisoft\Yii\Widgets\Breadcrumbs;
+use Yiisoft\Yii\Widgets\Menu;
 use Yiisoft\Yii\Widgets\Tests\Support\Assert;
 use Yiisoft\Yii\Widgets\Tests\Support\TestTrait;
 
@@ -33,6 +34,163 @@ final class BreadcrumbsTest extends TestCase
     public function testEmptyLinks(): void
     {
         $this->assertEmpty(Breadcrumbs::widget()->render());
+    }
+
+    public function testFromMenu(): void
+    {
+        $menu = Menu::widget()
+            ->items([
+                ['label' => 'Home', 'link' => '/'],
+                ['label' => 'About', 'link' => '/about'],
+            ])
+            ->currentPath('/about');
+
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <ul class="breadcrumb">
+            <li><a href="/">Home</a></li>
+            <li class="active">About</li>
+            </ul>
+            HTML,
+            Breadcrumbs::fromMenu($menu)->render(),
+        );
+    }
+
+    public function testFromMenuChaining(): void
+    {
+        $menu = Menu::widget()
+            ->items([
+                ['label' => 'About', 'link' => '/about', 'active' => true],
+            ]);
+
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <nav class="custom">
+            <li class="active">About</li>
+            </nav>
+            HTML,
+            Breadcrumbs::fromMenu($menu)
+                ->homeItem(null)
+                ->attributes(['class' => 'custom'])
+                ->tag('nav')
+                ->render(),
+        );
+    }
+
+    public function testFromMenuWithDeepNesting(): void
+    {
+        $menu = Menu::widget()
+            ->items([
+                ['label' => 'Level 1', 'link' => '/l1', 'items' => [
+                    ['label' => 'Level 2', 'link' => '/l2', 'items' => [
+                        ['label' => 'Level 3', 'link' => '/l3'],
+                    ]],
+                ]],
+            ])
+            ->currentPath('/l3');
+
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <ul class="breadcrumb">
+            <li><a href="/">Home</a></li>
+            <li><a href="/l1">Level 1</a></li>
+            <li><a href="/l2">Level 2</a></li>
+            <li class="active">Level 3</li>
+            </ul>
+            HTML,
+            Breadcrumbs::fromMenu($menu)->render(),
+        );
+    }
+
+    public function testFromMenuWithEncodeFalse(): void
+    {
+        $menu = Menu::widget()
+            ->items([
+                ['label' => '<b>Bold</b>', 'link' => '/bold', 'encode' => false, 'active' => true],
+            ]);
+
+        $this->assertSame(
+            "<li class=\"active\"><b>Bold</b></li>\n",
+            Breadcrumbs::fromMenu($menu)->homeItem(null)->tag('')->render(),
+        );
+    }
+
+    public function testFromMenuWithExplicitActive(): void
+    {
+        $menu = Menu::widget()
+            ->items([
+                ['label' => 'Home', 'link' => '/'],
+                ['label' => 'About', 'link' => '/about', 'active' => true],
+            ]);
+
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <ul class="breadcrumb">
+            <li><a href="/">Home</a></li>
+            <li class="active">About</li>
+            </ul>
+            HTML,
+            Breadcrumbs::fromMenu($menu)->render(),
+        );
+    }
+
+    public function testFromMenuWithInvisibleItem(): void
+    {
+        $menu = Menu::widget()
+            ->items([
+                ['label' => 'Products', 'link' => '/products', 'items' => [
+                    ['label' => 'Hidden', 'link' => '/products/hidden', 'visible' => false],
+                    ['label' => 'Widgets', 'link' => '/products/widgets'],
+                ]],
+            ])
+            ->currentPath('/products/widgets');
+
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <ul class="breadcrumb">
+            <li><a href="/">Home</a></li>
+            <li><a href="/products">Products</a></li>
+            <li class="active">Widgets</li>
+            </ul>
+            HTML,
+            Breadcrumbs::fromMenu($menu)->render(),
+        );
+    }
+
+    public function testFromMenuWithNestedItems(): void
+    {
+        $menu = Menu::widget()
+            ->items([
+                ['label' => 'Home', 'link' => '/'],
+                ['label' => 'Products', 'link' => '/products', 'items' => [
+                    ['label' => 'Widgets', 'link' => '/products/widgets'],
+                    ['label' => 'Gadgets', 'link' => '/products/gadgets'],
+                ]],
+            ])
+            ->currentPath('/products/widgets');
+
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <ul class="breadcrumb">
+            <li><a href="/">Home</a></li>
+            <li><a href="/products">Products</a></li>
+            <li class="active">Widgets</li>
+            </ul>
+            HTML,
+            Breadcrumbs::fromMenu($menu)->render(),
+        );
+    }
+
+    public function testFromMenuWithNoActiveItem(): void
+    {
+        $menu = Menu::widget()
+            ->items([
+                ['label' => 'Home', 'link' => '/'],
+                ['label' => 'About', 'link' => '/about'],
+            ])
+            ->currentPath('/unknown');
+
+        $this->assertEmpty(Breadcrumbs::fromMenu($menu)->render());
     }
 
     public function testHomeItem(): void

--- a/tests/Menu/ExceptionTest.php
+++ b/tests/Menu/ExceptionTest.php
@@ -13,6 +13,26 @@ final class ExceptionTest extends TestCase
 {
     use TestTrait;
 
+    public function testActiveTrailLabelNotString(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "label" option must be a string.');
+        Menu::widget()
+            ->items([['label' => 1, 'link' => '/test']])
+            ->currentPath('/test')
+            ->activeTrail();
+    }
+
+    public function testActiveTrailLabelRequired(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "label" option is required.');
+        Menu::widget()
+            ->items([['link' => '/test']])
+            ->currentPath('/test')
+            ->activeTrail();
+    }
+
     public function testAfterTag(): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Menu/MenuTest.php
+++ b/tests/Menu/MenuTest.php
@@ -89,6 +89,82 @@ final class MenuTest extends TestCase
         );
     }
 
+    public function testActiveTrail(): void
+    {
+        $this->assertSame(
+            [
+                ['label' => 'Products', 'url' => '/products'],
+                ['label' => 'Widgets'],
+            ],
+            Menu::widget()
+                ->items([
+                    ['label' => 'Home', 'link' => '/'],
+                    ['label' => 'Products', 'link' => '/products', 'items' => [
+                        ['label' => 'Widgets', 'link' => '/products/widgets'],
+                    ]],
+                ])
+                ->currentPath('/products/widgets')
+                ->activeTrail(),
+        );
+    }
+
+    public function testActiveTrailActiveAfterInactiveSubItems(): void
+    {
+        $this->assertSame(
+            [['label' => 'About']],
+            Menu::widget()
+                ->items([
+                    ['label' => 'Products', 'link' => '/products', 'items' => [
+                        ['label' => 'Widgets', 'link' => '/products/widgets'],
+                    ]],
+                    ['label' => 'About', 'link' => '/about'],
+                ])
+                ->currentPath('/about')
+                ->activeTrail(),
+        );
+    }
+
+    public function testActiveTrailEmpty(): void
+    {
+        $this->assertSame(
+            [],
+            Menu::widget()
+                ->items([
+                    ['label' => 'Home', 'link' => '/'],
+                ])
+                ->currentPath('/unknown')
+                ->activeTrail(),
+        );
+    }
+
+    public function testActiveTrailWithNonArrayItem(): void
+    {
+        $this->assertSame(
+            [['label' => 'About']],
+            Menu::widget()
+                ->items([
+                    '-',
+                    ['label' => 'About', 'link' => '/about'],
+                ])
+                ->currentPath('/about')
+                ->activeTrail(),
+        );
+    }
+
+    public function testActiveTrailWithActivateItemsFalse(): void
+    {
+        $this->assertSame(
+            [],
+            Menu::widget()
+                ->items([
+                    ['label' => 'About', 'link' => '/about'],
+                ])
+                ->currentPath('/about')
+                ->activateItems(false)
+                ->activeTrail(),
+        );
+    }
+
     public function testActiveWithNotBool(): void
     {
         Assert::equalsWithoutLE(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Docs added?   | ❌
| Tests added?  | ✔️
| Breaks BC?    | ❌

## What does this PR do?

Adds `Breadcrumbs::fromMenu()` static factory method that builds breadcrumbs automatically from the active trail in a `Menu` widget's item tree.

Navigation structure is often defined twice, in `Menu` (tree of items) and in `Breadcrumbs` (flat list of links), and they tend to get out of sync. `Breadcrumbs::fromMenu($menu)` walks the items tree, finds the active item by `currentPath` match or explicit `active` flag, collects the chain of ancestors, and returns a configured `Breadcrumbs` instance.

```php
$menu = Menu::widget()
    ->items([
        ['label' => 'Home', 'link' => '/'],
        ['label' => 'Products', 'link' => '/products', 'items' => [
            ['label' => 'Widgets', 'link' => '/products/widgets'],
        ]],
    ])
    ->currentPath('/products/widgets');

// Home > Products > Widgets
echo Breadcrumbs::fromMenu($menu)->render();
```

No BC break: only new public methods added (`Breadcrumbs::fromMenu()`, `Menu::activeTrail()`, `Normalizer::activeTrail()`), existing API unchanged.