### PR TITLE
Add conditional CSS class arrays to all `*Class()` methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Bug #113: Fix `array_merge()` argument order in `Menu::renderItem()` so that item-level `linkAttributes` override widget-level ones (@WarLikeLaux)
 - Enh #114: Add `readonly` to constructor-promoted properties in `Block`, `ContentDecorator`, and `FragmentCache` (@WarLikeLaux)
 - Enh #123: Remove redundant `array_merge()` call with single argument in `Dropdown` (@WarLikeLaux)
+- Enh #143: Add conditional CSS class arrays to all `*Class()` methods in `Alert`, `Dropdown`, and `Menu` (@WarLikeLaux)
 
 ## 2.1.1 September 23, 2025
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@
 - Bug #113: Fix `array_merge()` argument order in `Menu::renderItem()` so that item-level `linkAttributes` override widget-level ones (@WarLikeLaux)
 - Enh #114: Add `readonly` to constructor-promoted properties in `Block`, `ContentDecorator`, and `FragmentCache` (@WarLikeLaux)
 - Enh #123: Remove redundant `array_merge()` call with single argument in `Dropdown` (@WarLikeLaux)
-- Enh #143: Add conditional CSS class arrays to all `*Class()` methods in `Alert`, `Dropdown`, and `Menu` (@WarLikeLaux)
 - Enh #132: Remove raw keys from normalized items in `Normalizer::dropdown()` and `Normalizer::menu()` (@WarLikeLaux)
 - Bug #133: Fix `Alert::render()` returning empty string when body is empty but header is set (@WarLikeLaux)
 - New #126: Add `Menu::dropdownContainerAttributes()` method (@WarLikeLaux)
@@ -20,6 +19,7 @@
 - Bug #118: Add missing ARIA attributes to `Dropdown`, `Menu`, and `Alert` (@WarLikeLaux)
 - Enh #155: Add `url` as alias for `link` in `Menu` and `Dropdown` items (@WarLikeLaux)
 - Enh #157: Improve psalm type annotations (@Tigrov)
+- Enh #143: Add conditional CSS class arrays to all `*Class()` methods in `Alert`, `Dropdown`, and `Menu` (@WarLikeLaux)
 
 ## 2.1.1 September 23, 2025
 

--- a/src/Alert.php
+++ b/src/Alert.php
@@ -93,10 +93,10 @@ final class Alert extends Widget
      *
      * @param string $value The CSS class name.
      */
-    public function bodyClass(string $value): self
+    public function bodyClass(string|array $value): self
     {
         $new = clone $this;
-        Html::addCssClass($new->bodyAttributes, $value);
+        Html::addCssClass($new->bodyAttributes, Helper\Normalizer::cssClasses($value));
 
         return $new;
     }
@@ -134,10 +134,10 @@ final class Alert extends Widget
      *
      * @param string $value The CSS class name.
      */
-    public function bodyContainerClass(string $value): self
+    public function bodyContainerClass(string|array $value): self
     {
         $new = clone $this;
-        Html::addCssClass($new->bodyContainerAttributes, $value);
+        Html::addCssClass($new->bodyContainerAttributes, Helper\Normalizer::cssClasses($value));
 
         return $new;
     }
@@ -185,10 +185,10 @@ final class Alert extends Widget
      *
      * @param string $value The CSS class name.
      */
-    public function buttonClass(string $value): self
+    public function buttonClass(string|array $value): self
     {
         $new = clone $this;
-        Html::addCssClass($new->buttonAttributes, $value);
+        Html::addCssClass($new->buttonAttributes, Helper\Normalizer::cssClasses($value));
 
         return $new;
     }
@@ -224,10 +224,10 @@ final class Alert extends Widget
      *
      * @param string $value The CSS class name.
      */
-    public function class(string $value): self
+    public function class(string|array $value): self
     {
         $new = clone $this;
-        Html::addCssClass($new->attributes, $value);
+        Html::addCssClass($new->attributes, Helper\Normalizer::cssClasses($value));
 
         return $new;
     }
@@ -265,10 +265,10 @@ final class Alert extends Widget
      *
      * @param string $value The CSS class name.
      */
-    public function headerClass(string $value): self
+    public function headerClass(string|array $value): self
     {
         $new = clone $this;
-        Html::addCssClass($new->headerAttributes, $value);
+        Html::addCssClass($new->headerAttributes, Helper\Normalizer::cssClasses($value));
 
         return $new;
     }
@@ -306,10 +306,10 @@ final class Alert extends Widget
      *
      * @param string $value The CSS class name.
      */
-    public function headerContainerClass(string $value): self
+    public function headerContainerClass(string|array $value): self
     {
         $new = clone $this;
-        Html::addCssClass($new->headerContainerAttributes, $value);
+        Html::addCssClass($new->headerContainerAttributes, Helper\Normalizer::cssClasses($value));
 
         return $new;
     }
@@ -353,10 +353,10 @@ final class Alert extends Widget
      *
      * @param string $value The icon CSS class.
      */
-    public function iconClass(string $value): self
+    public function iconClass(string|array $value): self
     {
         $new = clone $this;
-        Html::addCssClass($new->iconAttributes, $value);
+        Html::addCssClass($new->iconAttributes, Helper\Normalizer::cssClasses($value));
 
         return $new;
     }
@@ -383,10 +383,10 @@ final class Alert extends Widget
      *
      * @param string $value The CSS class name.
      */
-    public function iconContainerClass(string $value): self
+    public function iconContainerClass(string|array $value): self
     {
         $new = clone $this;
-        Html::addCssClass($new->iconContainerAttributes, $value);
+        Html::addCssClass($new->iconContainerAttributes, Helper\Normalizer::cssClasses($value));
 
         return $new;
     }

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -54,10 +54,10 @@ final class Dropdown extends Widget
      *
      * @param string $value The active class.
      */
-    public function activeClass(string $value): self
+    public function activeClass(string|array $value): self
     {
         $new = clone $this;
-        $new->activeClass = $value;
+        $new->activeClass = Helper\Normalizer::cssClasses($value);
 
         return $new;
     }
@@ -93,10 +93,10 @@ final class Dropdown extends Widget
      *
      * @param string $value The container class.
      */
-    public function containerClass(string $value): self
+    public function containerClass(string|array $value): self
     {
         $new = clone $this;
-        $new->containerClass = $value;
+        $new->containerClass = Helper\Normalizer::cssClasses($value);
 
         return $new;
     }
@@ -118,10 +118,10 @@ final class Dropdown extends Widget
      *
      * @param string $value The disabled class.
      */
-    public function disabledClass(string $value): self
+    public function disabledClass(string|array $value): self
     {
         $new = clone $this;
-        $new->disabledClass = $value;
+        $new->disabledClass = Helper\Normalizer::cssClasses($value);
 
         return $new;
     }
@@ -144,10 +144,10 @@ final class Dropdown extends Widget
      *
      * @param string $value The divider class.
      */
-    public function dividerClass(string $value): self
+    public function dividerClass(string|array $value): self
     {
         $new = clone $this;
-        $new->dividerClass = $value;
+        $new->dividerClass = Helper\Normalizer::cssClasses($value);
 
         return $new;
     }
@@ -170,10 +170,10 @@ final class Dropdown extends Widget
      *
      * @param string $value The header class.
      */
-    public function headerClass(string $value): self
+    public function headerClass(string|array $value): self
     {
         $new = clone $this;
-        $new->headerClass = $value;
+        $new->headerClass = Helper\Normalizer::cssClasses($value);
 
         return $new;
     }
@@ -209,10 +209,10 @@ final class Dropdown extends Widget
      *
      * @param string $value The item class.
      */
-    public function itemClass(string $value): self
+    public function itemClass(string|array $value): self
     {
         $new = clone $this;
-        $new->itemClass = $value;
+        $new->itemClass = Helper\Normalizer::cssClasses($value);
 
         return $new;
     }
@@ -248,10 +248,10 @@ final class Dropdown extends Widget
      *
      * @param string $value The item container class.
      */
-    public function itemContainerClass(string $value): self
+    public function itemContainerClass(string|array $value): self
     {
         $new = clone $this;
-        Html::addCssClass($new->itemContainerAttributes, $value);
+        Html::addCssClass($new->itemContainerAttributes, Helper\Normalizer::cssClasses($value));
 
         return $new;
     }
@@ -329,10 +329,10 @@ final class Dropdown extends Widget
      *
      * @param string $value The item container class.
      */
-    public function itemsContainerClass(string $value): self
+    public function itemsContainerClass(string|array $value): self
     {
         $new = clone $this;
-        Html::addCssClass($new->itemsContainerAttributes, $value);
+        Html::addCssClass($new->itemsContainerAttributes, Helper\Normalizer::cssClasses($value));
 
         return $new;
     }
@@ -368,10 +368,10 @@ final class Dropdown extends Widget
      *
      * @param string $value The split button class.
      */
-    public function splitButtonClass(string $value): self
+    public function splitButtonClass(string|array $value): self
     {
         $new = clone $this;
-        Html::addCssClass($new->splitButtonAttributes, $value);
+        Html::addCssClass($new->splitButtonAttributes, Helper\Normalizer::cssClasses($value));
 
         return $new;
     }
@@ -381,10 +381,10 @@ final class Dropdown extends Widget
      *
      * @param string $value The split button span class.
      */
-    public function splitButtonSpanClass(string $value): self
+    public function splitButtonSpanClass(string|array $value): self
     {
         $new = clone $this;
-        Html::addCssClass($new->splitButtonSpanAttributes, $value);
+        Html::addCssClass($new->splitButtonSpanAttributes, Helper\Normalizer::cssClasses($value));
 
         return $new;
     }
@@ -407,10 +407,10 @@ final class Dropdown extends Widget
      *
      * @param string $value The toggle class.
      */
-    public function toggleClass(string $value): self
+    public function toggleClass(string|array $value): self
     {
         $new = clone $this;
-        Html::addCssClass($new->toggleAttributes, $value);
+        Html::addCssClass($new->toggleAttributes, Helper\Normalizer::cssClasses($value));
 
         return $new;
     }

--- a/src/Helper/Normalizer.php
+++ b/src/Helper/Normalizer.php
@@ -10,12 +10,42 @@ use Yiisoft\Html\Tag\I;
 use Yiisoft\Html\Tag\Span;
 
 use function array_key_exists;
+use function implode;
 use function is_array;
 use function is_bool;
+use function is_int;
 use function is_string;
 
 final class Normalizer
 {
+    /**
+     * Resolves conditional CSS classes to a string.
+     *
+     * Accepts a string (returned as-is), a list of class names, or an associative array where keys are class names
+     * and boolean values determine whether the class is included.
+     *
+     * @param string|array<array-key, string|bool> $value
+     */
+    public static function cssClasses(string|array $value): string
+    {
+        if (is_string($value)) {
+            return $value;
+        }
+
+        $classes = [];
+
+        foreach ($value as $class => $condition) {
+            if (is_int($class)) {
+                /** @var string $condition */
+                $classes[] = $condition;
+            } elseif ($condition) {
+                $classes[] = $class;
+            }
+        }
+
+        return implode(' ', $classes);
+    }
+
     /**
      * Normalize the given array of items for the dropdown.
      */

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -92,10 +92,10 @@ final class Menu extends Widget
      *
      * @param string $value The CSS class to be appended to the active menu item.
      */
-    public function activeClass(string $value): self
+    public function activeClass(string|array $value): self
     {
         $new = clone $this;
-        $new->activeClass = $value;
+        $new->activeClass = Helper\Normalizer::cssClasses($value);
 
         return $new;
     }
@@ -118,10 +118,10 @@ final class Menu extends Widget
      *
      * @param string $value The class name.
      */
-    public function afterClass(string $value): self
+    public function afterClass(string|array $value): self
     {
         $new = clone $this;
-        Html::addCssClass($new->afterAttributes, $value);
+        Html::addCssClass($new->afterAttributes, Helper\Normalizer::cssClasses($value));
 
         return $new;
     }
@@ -183,10 +183,10 @@ final class Menu extends Widget
      *
      * @param string $value The before container class.
      */
-    public function beforeClass(string $value): self
+    public function beforeClass(string|array $value): self
     {
         $new = clone $this;
-        Html::addCssClass($new->beforeAttributes, $value);
+        Html::addCssClass($new->beforeAttributes, Helper\Normalizer::cssClasses($value));
 
         return $new;
     }
@@ -222,10 +222,10 @@ final class Menu extends Widget
      *
      * @param string $value The class `menu` widget.
      */
-    public function class(string $value): self
+    public function class(string|array $value): self
     {
         $new = clone $this;
-        Html::addCssClass($new->attributes, $value);
+        Html::addCssClass($new->attributes, Helper\Normalizer::cssClasses($value));
 
         return $new;
     }
@@ -261,10 +261,10 @@ final class Menu extends Widget
      *
      * @param string $value The CSS class to be appended to the disabled menu item.
      */
-    public function disabledClass(string $value): self
+    public function disabledClass(string|array $value): self
     {
         $new = clone $this;
-        $new->disabledClass = $value;
+        $new->disabledClass = Helper\Normalizer::cssClasses($value);
 
         return $new;
     }
@@ -274,10 +274,10 @@ final class Menu extends Widget
      *
      * @param string $value The dropdown container class.
      */
-    public function dropdownContainerClass(string $value): self
+    public function dropdownContainerClass(string|array $value): self
     {
         $new = clone $this;
-        Html::addCssClass($new->dropdownContainerAttributes, $value);
+        Html::addCssClass($new->dropdownContainerAttributes, Helper\Normalizer::cssClasses($value));
 
         return $new;
     }
@@ -313,10 +313,10 @@ final class Menu extends Widget
      *
      * @param string $value The CSS class that will be assigned to the first item in the main menu or each submenu.
      */
-    public function firstItemClass(string $value): self
+    public function firstItemClass(string|array $value): self
     {
         $new = clone $this;
-        $new->firstItemClass = $value;
+        $new->firstItemClass = Helper\Normalizer::cssClasses($value);
 
         return $new;
     }
@@ -394,10 +394,10 @@ final class Menu extends Widget
      *
      * @param string $value The CSS class that will be assigned to the items' container.
      */
-    public function itemsContainerClass(string $value): self
+    public function itemsContainerClass(string|array $value): self
     {
         $new = clone $this;
-        Html::addCssClass($new->itemsContainerAttributes, $value);
+        Html::addCssClass($new->itemsContainerAttributes, Helper\Normalizer::cssClasses($value));
 
         return $new;
     }
@@ -420,10 +420,10 @@ final class Menu extends Widget
      *
      * @param string $value The CSS class that will be assigned to the last item in the main menu or each submenu.
      */
-    public function lastItemClass(string $value): self
+    public function lastItemClass(string|array $value): self
     {
         $new = clone $this;
-        $new->lastItemClass = $value;
+        $new->lastItemClass = Helper\Normalizer::cssClasses($value);
 
         return $new;
     }
@@ -446,10 +446,10 @@ final class Menu extends Widget
      *
      * @param string $value The CSS class that will be assigned to the link.
      */
-    public function linkClass(string $value): self
+    public function linkClass(string|array $value): self
     {
         $new = clone $this;
-        $new->linkClass = $value;
+        $new->linkClass = Helper\Normalizer::cssClasses($value);
 
         return $new;
     }

--- a/tests/Helper/NormalizerTest.php
+++ b/tests/Helper/NormalizerTest.php
@@ -12,6 +12,15 @@ use Yiisoft\Yii\Widgets\Helper\Normalizer;
  */
 final class NormalizerTest extends TestCase
 {
+    public function testCssClasses(): void
+    {
+        $this->assertSame('nav active', Normalizer::cssClasses('nav active'));
+        $this->assertSame('nav active', Normalizer::cssClasses(['nav', 'active']));
+        $this->assertSame('nav', Normalizer::cssClasses(['nav' => true, 'active' => false]));
+        $this->assertSame('nav active', Normalizer::cssClasses(['nav', 'active' => true, 'dark' => false]));
+        $this->assertSame('', Normalizer::cssClasses([]));
+    }
+
     public function testRenderLabel(): void
     {
         $this->assertSame('test', Normalizer::renderLabel('test', '', [], '', []));

--- a/tests/Menu/MenuTest.php
+++ b/tests/Menu/MenuTest.php
@@ -36,6 +36,22 @@ final class MenuTest extends TestCase
         );
     }
 
+    public function testActiveClassWithConditionalArray(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <ul>
+            <li><a aria-current="page" class="current highlight" href="/path">item</a></li>
+            </ul>
+            HTML,
+            Menu::widget()
+                ->activeClass(['current' => true, 'highlight' => true, 'hidden' => false])
+                ->currentPath('/path')
+                ->items($this->items)
+                ->render(),
+        );
+    }
+
     public function testActiveItemsWithFalse(): void
     {
         Assert::equalsWithoutLE(
@@ -154,6 +170,21 @@ final class MenuTest extends TestCase
             </ul>
             HTML,
             Menu::widget()->class('test-class')->items($this->items)->render(),
+        );
+    }
+
+    public function testClassWithConditionalArray(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <ul class="nav visible">
+            <li><a href="/path">item</a></li>
+            </ul>
+            HTML,
+            Menu::widget()
+                ->class(['nav' => true, 'visible' => true, 'dark' => false])
+                ->items($this->items)
+                ->render(),
         );
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Docs added?   | ❌
| Tests added?  | ✔️
| Breaks BC?    | ❌

## What does this PR do?

Extends all 29 `*Class()` methods in `Alert`, `Dropdown`, and `Menu` to accept `string|array`. The array format supports conditional CSS classes (Laravel Blade pattern).

```php
Menu::widget()
    ->class(['nav' => true, 'active' => $isActive, 'dark' => $isDark])
    ->activeClass(['selected' => true, 'highlight' => $isHighlighted])
    ->items($items)
    ->render();
```

Keys with `true` values are included, `false` are excluded. Numeric keys are always included. This replaces ternary expressions like `->class($active ? 'nav active' : 'nav')`.

Resolution logic is in `Normalizer::cssClasses()`. No BC break, existing string calls work unchanged.
