### PR TITLE
Add array support to `Alert::body()` for error lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Bug #113: Fix `array_merge()` argument order in `Menu::renderItem()` so that item-level `linkAttributes` override widget-level ones (@WarLikeLaux)
 - Enh #114: Add `readonly` to constructor-promoted properties in `Block`, `ContentDecorator`, and `FragmentCache` (@WarLikeLaux)
 - Enh #123: Remove redundant `array_merge()` call with single argument in `Dropdown` (@WarLikeLaux)
+- Enh #145: Add array support to `Alert::body()` for rendering error lists (@WarLikeLaux)
 
 ## 2.1.1 September 23, 2025
 

--- a/src/Alert.php
+++ b/src/Alert.php
@@ -12,6 +12,7 @@ use Yiisoft\Html\Tag\I;
 use Yiisoft\Widget\Widget;
 
 use function array_key_exists;
+use function is_array;
 use function strtr;
 use function trim;
 
@@ -29,12 +30,18 @@ final class Alert extends Widget
     private array $attributes = [];
     private array $buttonAttributes = [];
     private string $buttonLabel = '&times;';
-    private string $body = '';
+    /** @psalm-var string|string[] */
+    private string|array $body = '';
     private array $bodyAttributes = [];
-    /** @psalm-var non-empty-string */
-    private ?string $bodyTag = 'span';
     private bool $bodyContainer = false;
     private array $bodyContainerAttributes = [];
+    private array $bodyListAttributes = [];
+    /** @psalm-var non-empty-string */
+    private string $bodyListItemTag = 'li';
+    /** @psalm-var non-empty-string */
+    private string $bodyListTag = 'ul';
+    /** @psalm-var non-empty-string */
+    private ?string $bodyTag = 'span';
     private string $header = '';
     private array $headerAttributes = [];
     private bool $headerContainer = false;
@@ -63,9 +70,9 @@ final class Alert extends Widget
     /**
      * Returns a new instance with changed message body.
      *
-     * @param string $value The message body.
+     * @param string|string[] $value The message body. When an array is given, it is rendered as a list.
      */
-    public function body(string $value): self
+    public function body(string|array $value): self
     {
         $new = clone $this;
         $new->body = $value;
@@ -138,6 +145,45 @@ final class Alert extends Widget
     {
         $new = clone $this;
         Html::addCssClass($new->bodyContainerAttributes, $value);
+
+        return $new;
+    }
+
+    /**
+     * Returns a new instance with the CSS class for the body list container.
+     *
+     * @param string $value The CSS class name.
+     */
+    public function bodyListClass(string $value): self
+    {
+        $new = clone $this;
+        Html::addCssClass($new->bodyListAttributes, $value);
+
+        return $new;
+    }
+
+    /**
+     * Returns a new instance with the specified tag for body list items.
+     *
+     * @psalm-param non-empty-string $value
+     */
+    public function bodyListItemTag(string $value): self
+    {
+        $new = clone $this;
+        $new->bodyListItemTag = $value;
+
+        return $new;
+    }
+
+    /**
+     * Returns a new instance with the specified tag for the body list container.
+     *
+     * @psalm-param non-empty-string $value
+     */
+    public function bodyListTag(string $value): self
+    {
+        $new = clone $this;
+        $new->bodyListTag = $value;
 
         return $new;
     }
@@ -459,7 +505,7 @@ final class Alert extends Widget
 
         $contentAlert = $this->renderHeaderContainer($parts) . PHP_EOL . $this->renderBodyContainer($parts);
 
-        return $this->body !== ''
+        return ($this->body !== '' && $this->body !== [])
             ? $div
                 ->attribute('role', 'alert')
                 ->addAttributes($this->attributes)
@@ -502,9 +548,25 @@ final class Alert extends Widget
      */
     private function renderBody(): string
     {
+        $body = is_array($this->body) ? $this->renderBodyList($this->body) : $this->body;
+
         return $this->bodyTag !== null
-            ? Html::normalTag($this->bodyTag, $this->body, $this->bodyAttributes)->encode(false)->render()
-            : $this->body;
+            ? Html::normalTag($this->bodyTag, $body, $this->bodyAttributes)->encode(false)->render()
+            : $body;
+    }
+
+    private function renderBodyList(array $items): string
+    {
+        $listItems = '';
+
+        /** @var string $item */
+        foreach ($items as $item) {
+            $listItems .= Html::normalTag($this->bodyListItemTag, $item)->render();
+        }
+
+        return Html::normalTag($this->bodyListTag, $listItems, $this->bodyListAttributes)
+            ->encode(false)
+            ->render();
     }
 
     /**

--- a/tests/Alert/AlertTest.php
+++ b/tests/Alert/AlertTest.php
@@ -50,6 +50,67 @@ final class AlertTest extends TestCase
         );
     }
 
+    public function testBodyList(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <div role="alert" id="w0-alert">
+            <span><ul><li>Error 1</li><li>Error 2</li></ul></span>
+            <button type="button">&times;</button>
+            </div>
+            HTML,
+            Alert::widget()
+                ->body(['Error 1', 'Error 2'])
+                ->id('w0-alert')
+                ->render(),
+        );
+    }
+
+    public function testBodyListClass(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <div role="alert" id="w0-alert">
+            <span><ul class="error-list"><li>Error 1</li></ul></span>
+            <button type="button">&times;</button>
+            </div>
+            HTML,
+            Alert::widget()
+                ->body(['Error 1'])
+                ->bodyListClass('error-list')
+                ->id('w0-alert')
+                ->render(),
+        );
+    }
+
+    public function testBodyListCustomTags(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <div role="alert" id="w0-alert">
+            <span><ol><p>Error 1</p><p>Error 2</p></ol></span>
+            <button type="button">&times;</button>
+            </div>
+            HTML,
+            Alert::widget()
+                ->body(['Error 1', 'Error 2'])
+                ->bodyListTag('ol')
+                ->bodyListItemTag('p')
+                ->id('w0-alert')
+                ->render(),
+        );
+    }
+
+    public function testBodyListEmpty(): void
+    {
+        $this->assertEmpty(
+            Alert::widget()
+                ->body([])
+                ->id('w0-alert')
+                ->render(),
+        );
+    }
+
     public function testBodyWithoutTag(): void
     {
         Assert::equalsWithoutLE(

--- a/tests/Alert/ImmutableTest.php
+++ b/tests/Alert/ImmutableTest.php
@@ -23,6 +23,9 @@ final class ImmutableTest extends TestCase
         $this->assertNotSame($alert, $alert->bodyContainerAttributes([]));
         $this->assertNotSame($alert, $alert->bodyContainerClass(''));
         $this->assertNotSame($alert, $alert->bodyContainer(false));
+        $this->assertNotSame($alert, $alert->bodyListClass(''));
+        $this->assertNotSame($alert, $alert->bodyListItemTag('li'));
+        $this->assertNotSame($alert, $alert->bodyListTag('ul'));
         $this->assertNotSame($alert, $alert->buttonAttributes([]));
         $this->assertNotSame($alert, $alert->buttonClass(''));
         $this->assertNotSame($alert, $alert->buttonLabel());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Docs added?   | ❌
| Tests added?  | ✔️
| Breaks BC?    | ❌

## What does this PR do?

Extends `Alert::body()` to accept `string|array`. When an array is passed, it renders as an HTML list (`<ul><li>...</li></ul>` by default), which is the common pattern for displaying validation errors.

```php
Alert::widget()
    ->body(['Name is required.', 'Email is invalid.'])
    ->bodyListClass('error-list')
    ->render();
```

Three new methods for list customization: `bodyListTag(string)`, `bodyListItemTag(string)`, `bodyListClass(string)`. Empty arrays render nothing (same as empty string).

No BC break: existing string calls work unchanged.
