### PR TITLE
Fix #146: Add auto-generated ID to `Dropdown` for ARIA toggle-menu linkage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Bug #113: Fix `array_merge()` argument order in `Menu::renderItem()` so that item-level `linkAttributes` override widget-level ones (@WarLikeLaux)
 - Enh #114: Add `readonly` to constructor-promoted properties in `Block`, `ContentDecorator`, and `FragmentCache` (@WarLikeLaux)
 - Enh #123: Remove redundant `array_merge()` call with single argument in `Dropdown` (@WarLikeLaux)
+- Enh #146: Add auto-generated ID to `Dropdown` for ARIA toggle-menu linkage (@WarLikeLaux)
 
 ## 2.1.1 September 23, 2025
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
-         bootstrap="vendor/autoload.php"
+         bootstrap="tests/bootstrap.php"
          cacheDirectory=".phpunit.cache"
          requireCoverageMetadata="false"
          beStrictAboutCoverageMetadata="true"

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -455,8 +455,13 @@ final class Dropdown extends Widget
         $normalizedItems = Helper\Normalizer::dropdown($this->items);
 
         $containerAttributes = $this->containerAttributes;
+        $id = match (true) {
+            $this->id !== '' => $this->id,
+            $this->container => Html::generateId('dropdown-'),
+            default => '',
+        };
 
-        $items = $this->renderItems($normalizedItems) . PHP_EOL;
+        $items = $this->renderItems($normalizedItems, $id) . PHP_EOL;
 
         if (trim($items) === '') {
             return '';
@@ -548,7 +553,7 @@ final class Dropdown extends Widget
      *   items: array,
      * } $item
      */
-    private function renderItem(array $item): string
+    private function renderItem(array $item, string $id): string
     {
         if ($item['visible'] === false) {
             return '';
@@ -580,8 +585,8 @@ final class Dropdown extends Widget
                 $item['itemContainerAttributes'],
             );
         } else {
-            $itemContainer = $this->renderItemsContainer($this->renderDropdown($item['items']));
-            $toggle = $this->renderToggle($item['label'], $item['link'], $item['toggleAttributes']);
+            $itemContainer = $this->renderItemsContainer($this->renderDropdown($item['items']), $id);
+            $toggle = $this->renderToggle($item['label'], $item['link'], $id, $item['toggleAttributes']);
             $toggleSplitButton = $this->renderToggleSplitButton($item['label']);
 
             if ($this->toggleType === 'split' && !str_contains($this->containerClass, 'dropstart')) {
@@ -612,12 +617,12 @@ final class Dropdown extends Widget
             ->render();
     }
 
-    private function renderItemsContainer(string $content): string
+    private function renderItemsContainer(string $content, string $id): string
     {
         $itemsContainerAttributes = $this->itemsContainerAttributes;
 
-        if ($this->id !== '') {
-            $itemsContainerAttributes['aria-labelledby'] = $this->id;
+        if ($id !== '') {
+            $itemsContainerAttributes['aria-labelledby'] = $id;
         }
 
         if ($this->itemsContainerTag === '') {
@@ -665,13 +670,13 @@ final class Dropdown extends Widget
      *   }|string
      * > $items
      */
-    private function renderItems(array $items = []): string
+    private function renderItems(array $items, string $id): string
     {
         $lines = [];
 
         foreach ($items as $item) {
             $line = match (gettype($item)) {
-                'array' => $this->renderItem($item),
+                'array' => $this->renderItem($item, $id),
                 'string' => $this->renderDivider(),
             };
 
@@ -703,14 +708,14 @@ final class Dropdown extends Widget
         };
     }
 
-    private function renderToggle(string $label, string $link, array $toggleAttributes = []): string
+    private function renderToggle(string $label, string $link, string $id, array $toggleAttributes = []): string
     {
         if ($toggleAttributes === []) {
             $toggleAttributes = $this->toggleAttributes;
         }
 
-        if ($this->id !== '') {
-            $toggleAttributes['id'] = $this->id;
+        if ($id !== '') {
+            $toggleAttributes['id'] = $id;
         }
 
         return match ($this->toggleType) {

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -15,6 +15,7 @@ use Yiisoft\Html\Tag\Button;
 use Yiisoft\Html\Tag\Span;
 use Yiisoft\Widget\Widget;
 
+use function array_key_exists;
 use function gettype;
 use function implode;
 use function str_contains;
@@ -455,13 +456,8 @@ final class Dropdown extends Widget
         $normalizedItems = Helper\Normalizer::dropdown($this->items);
 
         $containerAttributes = $this->containerAttributes;
-        $id = match (true) {
-            $this->id !== '' => $this->id,
-            $this->container => Html::generateId('dropdown-'),
-            default => '',
-        };
 
-        $items = $this->renderItems($normalizedItems, $id) . PHP_EOL;
+        $items = $this->renderItems($normalizedItems) . PHP_EOL;
 
         if (trim($items) === '') {
             return '';
@@ -553,7 +549,7 @@ final class Dropdown extends Widget
      *   items: array,
      * } $item
      */
-    private function renderItem(array $item, string $id): string
+    private function renderItem(array $item): string
     {
         if ($item['visible'] === false) {
             return '';
@@ -585,6 +581,17 @@ final class Dropdown extends Widget
                 $item['itemContainerAttributes'],
             );
         } else {
+            $effectiveToggleAttributes = $item['toggleAttributes'] !== []
+                ? $item['toggleAttributes']
+                : $this->toggleAttributes;
+
+            $id = match (true) {
+                array_key_exists('id', $effectiveToggleAttributes) => (string) $effectiveToggleAttributes['id'],
+                $this->id !== '' => $this->id,
+                $this->container => Html::generateId('dropdown-'),
+                default => '',
+            };
+
             $itemContainer = $this->renderItemsContainer($this->renderDropdown($item['items']), $id);
             $toggle = $this->renderToggle($item['label'], $item['link'], $id, $item['toggleAttributes']);
             $toggleSplitButton = $this->renderToggleSplitButton($item['label']);
@@ -621,7 +628,7 @@ final class Dropdown extends Widget
     {
         $itemsContainerAttributes = $this->itemsContainerAttributes;
 
-        if ($id !== '') {
+        if ($id !== '' && !array_key_exists('aria-labelledby', $itemsContainerAttributes)) {
             $itemsContainerAttributes['aria-labelledby'] = $id;
         }
 
@@ -670,13 +677,13 @@ final class Dropdown extends Widget
      *   }|string
      * > $items
      */
-    private function renderItems(array $items, string $id): string
+    private function renderItems(array $items): string
     {
         $lines = [];
 
         foreach ($items as $item) {
             $line = match (gettype($item)) {
-                'array' => $this->renderItem($item, $id),
+                'array' => $this->renderItem($item),
                 'string' => $this->renderDivider(),
             };
 
@@ -714,7 +721,7 @@ final class Dropdown extends Widget
             $toggleAttributes = $this->toggleAttributes;
         }
 
-        if ($id !== '') {
+        if ($id !== '' && !array_key_exists('id', $toggleAttributes)) {
             $toggleAttributes['id'] = $id;
         }
 

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -590,8 +590,7 @@ final class Dropdown extends Widget
             $id = match (true) {
                 array_key_exists('id', $effectiveToggleAttributes) => (string) $effectiveToggleAttributes['id'],
                 $this->id !== '' => $this->id,
-                $this->container => Html::generateId('dropdown-'),
-                default => '',
+                default => Html::generateId('dropdown-'),
             };
 
             $itemContainer = $this->renderItemsContainer($this->renderDropdown($item['items']), $id);

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -596,7 +596,7 @@ final class Dropdown extends Widget
                 : $this->toggleAttributes;
 
             $id = match (true) {
-                array_key_exists('id', $toggleAttributes) => (string) $toggleAttributes['id'],
+                array_key_exists('id', $toggleAttributes) => $toggleAttributes['id'],
                 $this->id !== '' => $this->id,
                 default => Html::generateId('dropdown-'),
             };

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -591,18 +591,28 @@ final class Dropdown extends Widget
                 $item['itemContainerAttributes'],
             );
         } else {
-            $effectiveToggleAttributes = $item['toggleAttributes'] !== []
+            $toggleAttributes = $item['toggleAttributes'] !== []
                 ? $item['toggleAttributes']
                 : $this->toggleAttributes;
 
             $id = match (true) {
-                array_key_exists('id', $effectiveToggleAttributes) => (string) $effectiveToggleAttributes['id'],
+                array_key_exists('id', $toggleAttributes) => (string) $toggleAttributes['id'],
                 $this->id !== '' => $this->id,
                 default => Html::generateId('dropdown-'),
             };
 
-            $itemContainer = $this->renderItemsContainer($this->renderDropdown($item['items']), $id);
-            $toggle = $this->renderToggle($item['label'], $item['link'], $id, $item['toggleAttributes']);
+            if ($id !== '' && !array_key_exists('id', $toggleAttributes)) {
+                $toggleAttributes['id'] = $id;
+            }
+
+            $itemsContainerAttributes = $this->itemsContainerAttributes;
+
+            if ($id !== '' && !array_key_exists('aria-labelledby', $itemsContainerAttributes)) {
+                $itemsContainerAttributes['aria-labelledby'] = $id;
+            }
+
+            $itemContainer = $this->renderItemsContainer($this->renderDropdown($item['items']), $itemsContainerAttributes);
+            $toggle = $this->renderToggle($item['label'], $item['link'], $toggleAttributes);
             $toggleSplitButton = $this->renderToggleSplitButton($item['label']);
 
             if ($this->toggleType === 'split' && !str_contains($this->containerClass, 'dropstart')) {
@@ -633,14 +643,8 @@ final class Dropdown extends Widget
             ->render();
     }
 
-    private function renderItemsContainer(string $content, string $id): string
+    private function renderItemsContainer(string $content, array $itemsContainerAttributes): string
     {
-        $itemsContainerAttributes = $this->itemsContainerAttributes;
-
-        if ($id !== '' && !array_key_exists('aria-labelledby', $itemsContainerAttributes)) {
-            $itemsContainerAttributes['aria-labelledby'] = $id;
-        }
-
         if ($this->itemsContainerTag === '') {
             throw new InvalidArgumentException('Tag name must be a string and cannot be empty.');
         }
@@ -724,16 +728,8 @@ final class Dropdown extends Widget
         };
     }
 
-    private function renderToggle(string $label, string $link, string $id, array $toggleAttributes = []): string
+    private function renderToggle(string $label, string $link, array $toggleAttributes): string
     {
-        if ($toggleAttributes === []) {
-            $toggleAttributes = $this->toggleAttributes;
-        }
-
-        if ($id !== '' && !array_key_exists('id', $toggleAttributes)) {
-            $toggleAttributes['id'] = $id;
-        }
-
         return match ($this->toggleType) {
             'link' => $this->renderToggleLink($label, $link, $toggleAttributes),
             'split' => $this->renderToggleSplit($label, $toggleAttributes),

--- a/tests/Dropdown/Bootstrap5Test.php
+++ b/tests/Dropdown/Bootstrap5Test.php
@@ -33,8 +33,8 @@ final class Bootstrap5Test extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div class="btn-group">
-            <button aria-expanded="false" data-bs-toggle="dropdown" class="btn btn-secondary dropdown-toggle" type="button">Dropdown</button>
-            <ul class="dropdown-menu">
+            <button aria-expanded="false" data-bs-toggle="dropdown" class="btn btn-secondary dropdown-toggle" id="w0-dropdown" type="button">Dropdown</button>
+            <ul class="dropdown-menu" aria-labelledby="w0-dropdown">
             <li><h6 class="dropdown-header">Dropdown header</h6></li>
             <li><a class="dropdown-item" href="#">Action</a></li>
             <li><a class="dropdown-item" href="#">Another action</a></li>
@@ -42,6 +42,7 @@ final class Bootstrap5Test extends TestCase
             </div>
             HTML,
             Dropdown::widget([], $definitions)
+                ->id('w0-dropdown')
                 ->items(
                     [
                         [

--- a/tests/Dropdown/DropdownTest.php
+++ b/tests/Dropdown/DropdownTest.php
@@ -136,6 +136,45 @@ final class DropdownTest extends TestCase
         $this->assertStringContainsString('aria-labelledby="' . $matches[1] . '"', $result);
     }
 
+    public function testCustomToggleIdIsRespected(): void
+    {
+        $result = Dropdown::widget()
+            ->items([
+                [
+                    'label' => 'Toggle',
+                    'link' => '#',
+                    'toggleAttributes' => ['id' => 'custom-toggle'],
+                    'items' => [
+                        ['label' => 'Action', 'link' => '#'],
+                    ],
+                ],
+            ])
+            ->render();
+
+        $this->assertStringContainsString('id="custom-toggle"', $result);
+        $this->assertStringContainsString('aria-labelledby="custom-toggle"', $result);
+        $this->assertStringNotContainsString('id="dropdown-', $result);
+    }
+
+    public function testContainerFalseDoesNotGenerateId(): void
+    {
+        $result = Dropdown::widget()
+            ->container(false)
+            ->items([
+                [
+                    'label' => 'Toggle',
+                    'link' => '#',
+                    'items' => [
+                        ['label' => 'Action', 'link' => '#'],
+                    ],
+                ],
+            ])
+            ->render();
+
+        $this->assertStringNotContainsString('id="dropdown-', $result);
+        $this->assertStringNotContainsString('aria-labelledby', $result);
+    }
+
     public function testItemContainerWithFalse(): void
     {
         Assert::equalsWithoutLE(

--- a/tests/Dropdown/DropdownTest.php
+++ b/tests/Dropdown/DropdownTest.php
@@ -117,6 +117,25 @@ final class DropdownTest extends TestCase
         );
     }
 
+    public function testGenerateId(): void
+    {
+        $result = Dropdown::widget()
+            ->items([
+                [
+                    'label' => 'Toggle',
+                    'link' => '#',
+                    'items' => [
+                        ['label' => 'Action', 'link' => '#'],
+                    ],
+                ],
+            ])
+            ->render();
+
+        $this->assertMatchesRegularExpression('/id="(dropdown-\d+)"/', $result);
+        preg_match('/id="(dropdown-\d+)"/', $result, $matches);
+        $this->assertStringContainsString('aria-labelledby="' . $matches[1] . '"', $result);
+    }
+
     public function testItemContainerWithFalse(): void
     {
         Assert::equalsWithoutLE(

--- a/tests/Dropdown/DropdownTest.php
+++ b/tests/Dropdown/DropdownTest.php
@@ -156,7 +156,7 @@ final class DropdownTest extends TestCase
         $this->assertStringNotContainsString('id="dropdown-', $result);
     }
 
-    public function testContainerFalseDoesNotGenerateId(): void
+    public function testContainerFalseStillGeneratesIdForToggleMenuPair(): void
     {
         $result = Dropdown::widget()
             ->container(false)
@@ -171,8 +171,9 @@ final class DropdownTest extends TestCase
             ])
             ->render();
 
-        $this->assertStringNotContainsString('id="dropdown-', $result);
-        $this->assertStringNotContainsString('aria-labelledby', $result);
+        $this->assertMatchesRegularExpression('/id="(dropdown-\d+)"/', $result);
+        preg_match('/id="(dropdown-\d+)"/', $result, $matches);
+        $this->assertStringContainsString('aria-labelledby="' . $matches[1] . '"', $result);
     }
 
     public function testItemContainerWithFalse(): void

--- a/tests/Dropdown/DropdownTest.php
+++ b/tests/Dropdown/DropdownTest.php
@@ -176,6 +176,25 @@ final class DropdownTest extends TestCase
         $this->assertStringContainsString('aria-labelledby="' . $matches[1] . '"', $result);
     }
 
+    public function testPreserveExplicitAriaLabelledByOnSubmenuContainer(): void
+    {
+        $result = Dropdown::widget()
+            ->itemsContainerAttributes(['aria-labelledby' => 'explicit-submenu'])
+            ->items([
+                [
+                    'label' => 'Toggle',
+                    'link' => '#',
+                    'items' => [
+                        ['label' => 'Action', 'link' => '#'],
+                    ],
+                ],
+            ])
+            ->render();
+
+        $this->assertStringContainsString('aria-labelledby="explicit-submenu"', $result);
+        $this->assertStringNotContainsString('aria-labelledby="dropdown-', $result);
+    }
+
     public function testItemContainerWithFalse(): void
     {
         Assert::equalsWithoutLE(

--- a/tests/Dropdown/DropdownTest.php
+++ b/tests/Dropdown/DropdownTest.php
@@ -5,13 +5,16 @@ declare(strict_types=1);
 namespace Yiisoft\Yii\Widgets\Tests\Dropdown;
 
 use PHPUnit\Framework\TestCase;
+use Yiisoft\Html\IdGenerator;
 use Yiisoft\Yii\Widgets\Dropdown;
 use Yiisoft\Yii\Widgets\Tests\Support\Assert;
 use Yiisoft\Yii\Widgets\Tests\Support\TestTrait;
 
 final class DropdownTest extends TestCase
 {
-    use TestTrait;
+    use TestTrait {
+        TestTrait::setUp as setUpTestTrait;
+    }
 
     private array $items = [
         ['label' => 'Action', 'link' => '#', 'active' => true],
@@ -20,6 +23,19 @@ final class DropdownTest extends TestCase
         '-',
         ['label' => 'Separated link', 'link' => '#', 'disabled' => true],
     ];
+
+    protected function setUp(): void
+    {
+        $this->setUpTestTrait();
+
+        IdGenerator\disableSeed();
+        IdGenerator\reset();
+    }
+
+    protected function tearDown(): void
+    {
+        IdGenerator\enableSeed();
+    }
 
     public function testActiveClass(): void
     {
@@ -131,9 +147,8 @@ final class DropdownTest extends TestCase
             ])
             ->render();
 
-        $this->assertMatchesRegularExpression('/id="(dropdown-\d+)"/', $result);
-        preg_match('/id="(dropdown-\d+)"/', $result, $matches);
-        $this->assertStringContainsString('aria-labelledby="' . $matches[1] . '"', $result);
+        $this->assertStringContainsString('id="dropdown-1"', $result);
+        $this->assertStringContainsString('aria-labelledby="dropdown-1"', $result);
     }
 
     public function testCustomToggleIdIsRespected(): void
@@ -171,9 +186,8 @@ final class DropdownTest extends TestCase
             ])
             ->render();
 
-        $this->assertMatchesRegularExpression('/id="(dropdown-\d+)"/', $result);
-        preg_match('/id="(dropdown-\d+)"/', $result, $matches);
-        $this->assertStringContainsString('aria-labelledby="' . $matches[1] . '"', $result);
+        $this->assertStringContainsString('id="dropdown-1"', $result);
+        $this->assertStringContainsString('aria-labelledby="dropdown-1"', $result);
     }
 
     public function testPreserveExplicitAriaLabelledByOnSubmenuContainer(): void

--- a/tests/Dropdown/DropdownTest.php
+++ b/tests/Dropdown/DropdownTest.php
@@ -410,13 +410,14 @@ final class DropdownTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div>
-            <button type="button"><span><i class="bi bi-star">star</i></span>Parent</button>
-            <ul>
+            <button id="test" type="button"><span><i class="bi bi-star">star</i></span>Parent</button>
+            <ul aria-labelledby="test">
             <li><a href="#"><span><i class="bi bi-house">house</i></span>Child</a></li>
             </ul>
             </div>
             HTML,
             Dropdown::widget()
+                ->id('test')
                 ->items([
                     [
                         'label' => 'Parent',
@@ -437,13 +438,14 @@ final class DropdownTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div>
-            <a href="#"><span><i class="bi bi-star">star</i></span>Parent</a>
-            <ul>
+            <a id="test" href="#"><span><i class="bi bi-star">star</i></span>Parent</a>
+            <ul aria-labelledby="test">
             <li><a href="#">Child</a></li>
             </ul>
             </div>
             HTML,
             Dropdown::widget()
+                ->id('test')
                 ->toggleType('link')
                 ->items([
                     [
@@ -464,13 +466,14 @@ final class DropdownTest extends TestCase
             <<<HTML
             <div>
             <button type="button"><span><i class="bi bi-star">star</i></span>Parent</button>
-            <button type="button"><span><span><i class="bi bi-star">star</i></span>Parent</span></button>
-            <ul>
+            <button id="test" type="button"><span><span><i class="bi bi-star">star</i></span>Parent</span></button>
+            <ul aria-labelledby="test">
             <li><a href="#">Child</a></li>
             </ul>
             </div>
             HTML,
             Dropdown::widget()
+                ->id('test')
                 ->toggleType('split')
                 ->items([
                     [

--- a/tests/Menu/MenuTest.php
+++ b/tests/Menu/MenuTest.php
@@ -6,6 +6,7 @@ namespace Yiisoft\Yii\Widgets\Tests\Menu;
 
 use PHPUnit\Framework\TestCase;
 use Stringable;
+use Yiisoft\Html\IdGenerator;
 use Yiisoft\Yii\Widgets\Menu;
 use Yiisoft\Yii\Widgets\Tests\Support\Assert;
 use Yiisoft\Yii\Widgets\Tests\Support\TestTrait;
@@ -13,7 +14,9 @@ use InvalidArgumentException;
 
 final class MenuTest extends TestCase
 {
-    use TestTrait;
+    use TestTrait {
+        TestTrait::setUp as setUpTestTrait;
+    }
 
     private array $items = [
         ['label' => 'item', 'link' => '/path'],
@@ -24,6 +27,19 @@ final class MenuTest extends TestCase
         ['label' => 'Link', 'link' => '#'],
         ['label' => 'Disabled', 'link' => '#', 'disabled' => true],
     ];
+
+    protected function setUp(): void
+    {
+        $this->setUpTestTrait();
+
+        IdGenerator\disableSeed();
+        IdGenerator\reset();
+    }
+
+    protected function tearDown(): void
+    {
+        IdGenerator\enableSeed();
+    }
 
     public function testAttributes(): void
     {
@@ -188,9 +204,24 @@ final class MenuTest extends TestCase
 
     public function testDropdown(): void
     {
-        $html = (string) preg_replace(
-            '/dropdown-\d+/',
-            'dropdown-ID',
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <ul>
+            <li><a aria-current="page" class="active" href="/active">Active</a></li>
+            <li>
+            <a aria-expanded="false" data-bs-toggle="dropdown" role="button" id="dropdown-1" href="#">Dropdown</a>
+            <ul aria-labelledby="dropdown-1">
+            <li><a href="#">Action</a></li>
+            <li><a href="#">Another action</a></li>
+            <li><a href="#">Something else here</a></li>
+            <li><hr class="dropdown-divider"></li>
+            <li><a href="#">Separated link</a></li>
+            </ul>
+            </li>
+            <li><a href="#">Link</a></li>
+            <li><a aria-disabled="true" class="disabled" href="#">Disabled</a></li>
+            </ul>
+            HTML,
             Menu::widget()
                 ->currentPath('/active')
                 ->items(
@@ -213,34 +244,22 @@ final class MenuTest extends TestCase
                 )
                 ->render(),
         );
-
-        Assert::equalsWithoutLE(
-            <<<HTML
-            <ul>
-            <li><a aria-current="page" class="active" href="/active">Active</a></li>
-            <li>
-            <a aria-expanded="false" data-bs-toggle="dropdown" role="button" id="dropdown-ID" href="#">Dropdown</a>
-            <ul aria-labelledby="dropdown-ID">
-            <li><a href="#">Action</a></li>
-            <li><a href="#">Another action</a></li>
-            <li><a href="#">Something else here</a></li>
-            <li><hr class="dropdown-divider"></li>
-            <li><a href="#">Separated link</a></li>
-            </ul>
-            </li>
-            <li><a href="#">Link</a></li>
-            <li><a aria-disabled="true" class="disabled" href="#">Disabled</a></li>
-            </ul>
-            HTML,
-            $html,
-        );
     }
 
     public function testDropdownContainerAttributes(): void
     {
-        $html = (string) preg_replace(
-            '/dropdown-\d+/',
-            'dropdown-ID',
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <ul>
+            <li><a aria-current="page" class="active" href="/active">Active</a></li>
+            <li data-test="value">
+            <a aria-expanded="false" data-bs-toggle="dropdown" role="button" id="dropdown-1" href="#">Dropdown</a>
+            <ul aria-labelledby="dropdown-1">
+            <li><a href="#">Action</a></li>
+            </ul>
+            </li>
+            </ul>
+            HTML,
             Menu::widget()
                 ->currentPath('/active')
                 ->dropdownContainerAttributes(['data-test' => 'value'])
@@ -258,28 +277,28 @@ final class MenuTest extends TestCase
                 )
                 ->render(),
         );
-
-        Assert::equalsWithoutLE(
-            <<<HTML
-            <ul>
-            <li><a aria-current="page" class="active" href="/active">Active</a></li>
-            <li data-test="value">
-            <a aria-expanded="false" data-bs-toggle="dropdown" role="button" id="dropdown-ID" href="#">Dropdown</a>
-            <ul aria-labelledby="dropdown-ID">
-            <li><a href="#">Action</a></li>
-            </ul>
-            </li>
-            </ul>
-            HTML,
-            $html,
-        );
     }
 
     public function testDropdownContainerClass(): void
     {
-        $html = (string) preg_replace(
-            '/dropdown-\d+/',
-            'dropdown-ID',
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <ul>
+            <li><a aria-current="page" class="active" href="/active">Active</a></li>
+            <li class="nav-item dropdown">
+            <a aria-expanded="false" data-bs-toggle="dropdown" role="button" id="dropdown-1" href="#">Dropdown</a>
+            <ul aria-labelledby="dropdown-1">
+            <li><a href="#">Action</a></li>
+            <li><a href="#">Another action</a></li>
+            <li><a href="#">Something else here</a></li>
+            <li><hr class="dropdown-divider"></li>
+            <li><a href="#">Separated link</a></li>
+            </ul>
+            </li>
+            <li><a href="#">Link</a></li>
+            <li><a aria-disabled="true" class="disabled" href="#">Disabled</a></li>
+            </ul>
+            HTML,
             Menu::widget()
                 ->currentPath('/active')
                 ->dropdownContainerClass('nav-item dropdown')
@@ -303,34 +322,28 @@ final class MenuTest extends TestCase
                 )
                 ->render(),
         );
+    }
 
+    public function testDropdownDefinitions(): void
+    {
         Assert::equalsWithoutLE(
             <<<HTML
             <ul>
             <li><a aria-current="page" class="active" href="/active">Active</a></li>
-            <li class="nav-item dropdown">
-            <a aria-expanded="false" data-bs-toggle="dropdown" role="button" id="dropdown-ID" href="#">Dropdown</a>
-            <ul aria-labelledby="dropdown-ID">
-            <li><a href="#">Action</a></li>
-            <li><a href="#">Another action</a></li>
-            <li><a href="#">Something else here</a></li>
+            <li>
+            <a aria-expanded="false" data-bs-toggle="dropdown" role="button" class="dropdown-toggle" id="dropdown-1" href="#">Dropdown</a>
+            <ul class="dropdown-menu" aria-labelledby="dropdown-1">
+            <li><a class="dropdown-item" href="#">Action</a></li>
+            <li><a class="dropdown-item" href="#">Another action</a></li>
+            <li><a class="dropdown-item" href="#">Something else here</a></li>
             <li><hr class="dropdown-divider"></li>
-            <li><a href="#">Separated link</a></li>
+            <li><a class="dropdown-item" href="#">Separated link</a></li>
             </ul>
             </li>
             <li><a href="#">Link</a></li>
             <li><a aria-disabled="true" class="disabled" href="#">Disabled</a></li>
             </ul>
             HTML,
-            $html,
-        );
-    }
-
-    public function testDropdownDefinitions(): void
-    {
-        $html = (string) preg_replace(
-            '/dropdown-\d+/',
-            'dropdown-ID',
             Menu::widget()
                 ->currentPath('/active')
                 ->dropdownDefinitions(
@@ -370,27 +383,6 @@ final class MenuTest extends TestCase
                     ],
                 )
                 ->render(),
-        );
-
-        Assert::equalsWithoutLE(
-            <<<HTML
-            <ul>
-            <li><a aria-current="page" class="active" href="/active">Active</a></li>
-            <li>
-            <a aria-expanded="false" data-bs-toggle="dropdown" role="button" class="dropdown-toggle" id="dropdown-ID" href="#">Dropdown</a>
-            <ul class="dropdown-menu" aria-labelledby="dropdown-ID">
-            <li><a class="dropdown-item" href="#">Action</a></li>
-            <li><a class="dropdown-item" href="#">Another action</a></li>
-            <li><a class="dropdown-item" href="#">Something else here</a></li>
-            <li><hr class="dropdown-divider"></li>
-            <li><a class="dropdown-item" href="#">Separated link</a></li>
-            </ul>
-            </li>
-            <li><a href="#">Link</a></li>
-            <li><a aria-disabled="true" class="disabled" href="#">Disabled</a></li>
-            </ul>
-            HTML,
-            $html,
         );
     }
 

--- a/tests/Menu/MenuTest.php
+++ b/tests/Menu/MenuTest.php
@@ -188,24 +188,9 @@ final class MenuTest extends TestCase
 
     public function testDropdown(): void
     {
-        Assert::equalsWithoutLE(
-            <<<HTML
-            <ul>
-            <li><a aria-current="page" class="active" href="/active">Active</a></li>
-            <li>
-            <a aria-expanded="false" data-bs-toggle="dropdown" role="button" href="#">Dropdown</a>
-            <ul>
-            <li><a href="#">Action</a></li>
-            <li><a href="#">Another action</a></li>
-            <li><a href="#">Something else here</a></li>
-            <li><hr class="dropdown-divider"></li>
-            <li><a href="#">Separated link</a></li>
-            </ul>
-            </li>
-            <li><a href="#">Link</a></li>
-            <li><a aria-disabled="true" class="disabled" href="#">Disabled</a></li>
-            </ul>
-            HTML,
+        $html = (string) preg_replace(
+            '/dropdown-\d+/',
+            'dropdown-ID',
             Menu::widget()
                 ->currentPath('/active')
                 ->items(
@@ -228,22 +213,34 @@ final class MenuTest extends TestCase
                 )
                 ->render(),
         );
-    }
 
-    public function testDropdownContainerAttributes(): void
-    {
         Assert::equalsWithoutLE(
             <<<HTML
             <ul>
             <li><a aria-current="page" class="active" href="/active">Active</a></li>
-            <li data-test="value">
-            <a aria-expanded="false" data-bs-toggle="dropdown" role="button" href="#">Dropdown</a>
-            <ul>
+            <li>
+            <a aria-expanded="false" data-bs-toggle="dropdown" role="button" id="dropdown-ID" href="#">Dropdown</a>
+            <ul aria-labelledby="dropdown-ID">
             <li><a href="#">Action</a></li>
+            <li><a href="#">Another action</a></li>
+            <li><a href="#">Something else here</a></li>
+            <li><hr class="dropdown-divider"></li>
+            <li><a href="#">Separated link</a></li>
             </ul>
             </li>
+            <li><a href="#">Link</a></li>
+            <li><a aria-disabled="true" class="disabled" href="#">Disabled</a></li>
             </ul>
             HTML,
+            $html,
+        );
+    }
+
+    public function testDropdownContainerAttributes(): void
+    {
+        $html = (string) preg_replace(
+            '/dropdown-\d+/',
+            'dropdown-ID',
             Menu::widget()
                 ->currentPath('/active')
                 ->dropdownContainerAttributes(['data-test' => 'value'])
@@ -261,28 +258,28 @@ final class MenuTest extends TestCase
                 )
                 ->render(),
         );
-    }
 
-    public function testDropdownContainerClass(): void
-    {
         Assert::equalsWithoutLE(
             <<<HTML
             <ul>
             <li><a aria-current="page" class="active" href="/active">Active</a></li>
-            <li class="nav-item dropdown">
-            <a aria-expanded="false" data-bs-toggle="dropdown" role="button" href="#">Dropdown</a>
-            <ul>
+            <li data-test="value">
+            <a aria-expanded="false" data-bs-toggle="dropdown" role="button" id="dropdown-ID" href="#">Dropdown</a>
+            <ul aria-labelledby="dropdown-ID">
             <li><a href="#">Action</a></li>
-            <li><a href="#">Another action</a></li>
-            <li><a href="#">Something else here</a></li>
-            <li><hr class="dropdown-divider"></li>
-            <li><a href="#">Separated link</a></li>
             </ul>
             </li>
-            <li><a href="#">Link</a></li>
-            <li><a aria-disabled="true" class="disabled" href="#">Disabled</a></li>
             </ul>
             HTML,
+            $html,
+        );
+    }
+
+    public function testDropdownContainerClass(): void
+    {
+        $html = (string) preg_replace(
+            '/dropdown-\d+/',
+            'dropdown-ID',
             Menu::widget()
                 ->currentPath('/active')
                 ->dropdownContainerClass('nav-item dropdown')
@@ -306,28 +303,34 @@ final class MenuTest extends TestCase
                 )
                 ->render(),
         );
-    }
 
-    public function testDropdownDefinitions(): void
-    {
         Assert::equalsWithoutLE(
             <<<HTML
             <ul>
             <li><a aria-current="page" class="active" href="/active">Active</a></li>
-            <li>
-            <a aria-expanded="false" data-bs-toggle="dropdown" role="button" class="dropdown-toggle" href="#">Dropdown</a>
-            <ul class="dropdown-menu">
-            <li><a class="dropdown-item" href="#">Action</a></li>
-            <li><a class="dropdown-item" href="#">Another action</a></li>
-            <li><a class="dropdown-item" href="#">Something else here</a></li>
+            <li class="nav-item dropdown">
+            <a aria-expanded="false" data-bs-toggle="dropdown" role="button" id="dropdown-ID" href="#">Dropdown</a>
+            <ul aria-labelledby="dropdown-ID">
+            <li><a href="#">Action</a></li>
+            <li><a href="#">Another action</a></li>
+            <li><a href="#">Something else here</a></li>
             <li><hr class="dropdown-divider"></li>
-            <li><a class="dropdown-item" href="#">Separated link</a></li>
+            <li><a href="#">Separated link</a></li>
             </ul>
             </li>
             <li><a href="#">Link</a></li>
             <li><a aria-disabled="true" class="disabled" href="#">Disabled</a></li>
             </ul>
             HTML,
+            $html,
+        );
+    }
+
+    public function testDropdownDefinitions(): void
+    {
+        $html = (string) preg_replace(
+            '/dropdown-\d+/',
+            'dropdown-ID',
             Menu::widget()
                 ->currentPath('/active')
                 ->dropdownDefinitions(
@@ -367,6 +370,27 @@ final class MenuTest extends TestCase
                     ],
                 )
                 ->render(),
+        );
+
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <ul>
+            <li><a aria-current="page" class="active" href="/active">Active</a></li>
+            <li>
+            <a aria-expanded="false" data-bs-toggle="dropdown" role="button" class="dropdown-toggle" id="dropdown-ID" href="#">Dropdown</a>
+            <ul class="dropdown-menu" aria-labelledby="dropdown-ID">
+            <li><a class="dropdown-item" href="#">Action</a></li>
+            <li><a class="dropdown-item" href="#">Another action</a></li>
+            <li><a class="dropdown-item" href="#">Something else here</a></li>
+            <li><hr class="dropdown-divider"></li>
+            <li><a class="dropdown-item" href="#">Separated link</a></li>
+            </ul>
+            </li>
+            <li><a href="#">Link</a></li>
+            <li><a aria-disabled="true" class="disabled" href="#">Disabled</a></li>
+            </ul>
+            HTML,
+            $html,
         );
     }
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,6 @@
+<?php
+
+declare(strict_types=1);
+
+require_once \dirname(__DIR__) . '/vendor/autoload.php';
+require_once \dirname(__DIR__) . '/vendor/yiisoft/html/src/test-functions.php';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Docs added?   | ❌
| Tests added?  | ✔️
| Breaks BC?    | ❌

## What does this PR do?

Adds auto-generated IDs to `Dropdown` items that render a toggle and menu so the menu can reference the toggle with `aria-labelledby`.

When a toggle ID is already set in item-level `toggleAttributes`, it is preserved and used for `aria-labelledby`. When widget-level `id()` is set, that value is used. Otherwise, `Dropdown` generates a unique `dropdown-*` ID for the toggle/menu pair.

This also works when `container(false)` is used, including dropdowns rendered by `Menu`.

No BC break: the public API is unchanged, explicit IDs and `aria-labelledby` values are preserved, and the new output only adds missing accessibility attributes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dropdown components now auto-generate stable IDs for improved accessibility with ARIA toggle-menu linkage. Custom IDs can still be provided via toggle attributes.

* **Tests**
  * Added test coverage for ID generation behavior across multiple dropdown scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yiisoft/yii-widgets/pull/146?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->