### PR TITLE
Add `pipe()` method to all widgets via `PipeTrait`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Bug #113: Fix `array_merge()` argument order in `Menu::renderItem()` so that item-level `linkAttributes` override widget-level ones (@WarLikeLaux)
 - Enh #114: Add `readonly` to constructor-promoted properties in `Block`, `ContentDecorator`, and `FragmentCache` (@WarLikeLaux)
 - Enh #123: Remove redundant `array_merge()` call with single argument in `Dropdown` (@WarLikeLaux)
+- New #147: Add `pipe()` method for composable widget theming to all widgets (@WarLikeLaux)
 
 ## 2.1.1 September 23, 2025
 

--- a/src/Alert.php
+++ b/src/Alert.php
@@ -26,6 +26,8 @@ use const PHP_EOL;
  */
 final class Alert extends Widget
 {
+    use PipeTrait;
+
     private array $attributes = [];
     private array $buttonAttributes = [];
     private string $buttonLabel = '&times;';

--- a/src/Block.php
+++ b/src/Block.php
@@ -43,6 +43,8 @@ use function ob_start;
  */
 final class Block extends Widget
 {
+    use PipeTrait;
+
     private string $id = '';
     private bool $renderInPlace = false;
 

--- a/src/Breadcrumbs.php
+++ b/src/Breadcrumbs.php
@@ -52,6 +52,8 @@ use const PHP_EOL;
  */
 final class Breadcrumbs extends Widget
 {
+    use PipeTrait;
+
     private string $activeItemTemplate = "<li class=\"active\">{link}</li>\n";
     private array $attributes = ['class' => 'breadcrumb'];
     private ?array $homeItem = ['label' => 'Home', 'url' => '/'];

--- a/src/ContentDecorator.php
+++ b/src/ContentDecorator.php
@@ -31,6 +31,8 @@ use function ob_start;
  */
 final class ContentDecorator extends Widget
 {
+    use PipeTrait;
+
     private array $parameters = [];
     private string $viewFile = '';
 

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -24,6 +24,8 @@ use const PHP_EOL;
 
 final class Dropdown extends Widget
 {
+    use PipeTrait;
+
     private string $activeClass = 'active';
     private bool $container = true;
     private array $containerAttributes = [];

--- a/src/FragmentCache.php
+++ b/src/FragmentCache.php
@@ -41,6 +41,8 @@ use function ob_start;
  */
 final class FragmentCache extends Widget
 {
+    use PipeTrait;
+
     private ?Dependency $dependency = null;
     private string $id = '';
     private int $ttl = 60;

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -44,6 +44,8 @@ use const PHP_EOL;
  */
 final class Menu extends Widget
 {
+    use PipeTrait;
+
     private array $afterAttributes = [];
     private string $afterContent = '';
     private string $afterTag = 'span';

--- a/src/PipeTrait.php
+++ b/src/PipeTrait.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Yii\Widgets;
+
+/**
+ * Provides fluent pipe for composable widget configuration.
+ */
+trait PipeTrait
+{
+    /**
+     * Passes this instance through the callback, returning the result.
+     *
+     * @param callable(static): static $callback The callback to apply.
+     */
+    public function pipe(callable $callback): static
+    {
+        return $callback($this);
+    }
+}

--- a/tests/Alert/ImmutableTest.php
+++ b/tests/Alert/ImmutableTest.php
@@ -43,5 +43,6 @@ final class ImmutableTest extends TestCase
         $this->assertNotSame($alert, $alert->iconText(''));
         $this->assertNotSame($alert, $alert->layoutBody(''));
         $this->assertNotSame($alert, $alert->layoutHeader(''));
+        $this->assertNotSame($alert, $alert->pipe(static fn(Alert $a) => $a->body('test')));
     }
 }

--- a/tests/Block/ImmutableTest.php
+++ b/tests/Block/ImmutableTest.php
@@ -17,5 +17,6 @@ final class ImmutableTest extends TestCase
         $block = Block::widget();
         $this->assertNotSame($block, $block->id(Block::class));
         $this->assertNotSame($block, $block->renderInPlace());
+        $this->assertNotSame($block, $block->pipe(static fn(Block $b) => $b->id('test')));
     }
 }

--- a/tests/Breadcrumbs/ImmutableTest.php
+++ b/tests/Breadcrumbs/ImmutableTest.php
@@ -21,5 +21,6 @@ final class ImmutableTest extends TestCase
         $this->assertNotSame($breadcrumbs, $breadcrumbs->items(['label' => 'value']));
         $this->assertNotSame($breadcrumbs, $breadcrumbs->itemTemplate(''));
         $this->assertNotSame($breadcrumbs, $breadcrumbs->tag('ul'));
+        $this->assertNotSame($breadcrumbs, $breadcrumbs->pipe(static fn(Breadcrumbs $b) => $b->tag('div')));
     }
 }

--- a/tests/ContentDecorator/ImmutableTest.php
+++ b/tests/ContentDecorator/ImmutableTest.php
@@ -17,5 +17,6 @@ final class ImmutableTest extends TestCase
         $contentDecorator = ContentDecorator::widget();
         $this->assertNotSame($contentDecorator, $contentDecorator->parameters([]));
         $this->assertNotSame($contentDecorator, $contentDecorator->viewFile(''));
+        $this->assertNotSame($contentDecorator, $contentDecorator->pipe(static fn(ContentDecorator $c) => $c->viewFile('test')));
     }
 }

--- a/tests/Dropdown/ImmutableTest.php
+++ b/tests/Dropdown/ImmutableTest.php
@@ -43,5 +43,6 @@ final class ImmutableTest extends TestCase
         $this->assertNotSame($dropdown, $dropdown->toggleAttributes([]));
         $this->assertNotSame($dropdown, $dropdown->toggleClass(''));
         $this->assertNotSame($dropdown, $dropdown->toggleType(''));
+        $this->assertNotSame($dropdown, $dropdown->pipe(static fn(Dropdown $d) => $d->activeClass('test')));
     }
 }

--- a/tests/FragmentCache/ImmutableTest.php
+++ b/tests/FragmentCache/ImmutableTest.php
@@ -22,5 +22,6 @@ final class ImmutableTest extends TestCase
         $this->assertNotSame($widget, $widget->dependency(new TagDependency('test')));
         $this->assertNotSame($widget, $widget->dynamicContents(new DynamicContent('test', fn(): string => 'test')));
         $this->assertNotSame($widget, $widget->variations(''));
+        $this->assertNotSame($widget, $widget->pipe(static fn(FragmentCache $w) => $w->id('test')));
     }
 }

--- a/tests/Menu/ImmutableTest.php
+++ b/tests/Menu/ImmutableTest.php
@@ -46,5 +46,6 @@ final class ImmutableTest extends TestCase
         $this->assertNotSame($menu, $menu->linkTag(''));
         $this->assertNotSame($menu, $menu->tagName(''));
         $this->assertNotSame($menu, $menu->template(''));
+        $this->assertNotSame($menu, $menu->pipe(static fn(Menu $m) => $m->class('test')));
     }
 }

--- a/tests/Menu/MenuTest.php
+++ b/tests/Menu/MenuTest.php
@@ -639,6 +639,23 @@ final class MenuTest extends TestCase
         );
     }
 
+    public function testPipe(): void
+    {
+        $addNavClass = static fn(Menu $m) => $m->class('nav');
+
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <ul class="nav">
+            <li><a href="/path">item</a></li>
+            </ul>
+            HTML,
+            Menu::widget()
+                ->items($this->items)
+                ->pipe($addNavClass)
+                ->render(),
+        );
+    }
+
     public function testAfterContentWithStringable(): void
     {
         $stringable = new class implements Stringable {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Docs added?   | ❌
| Tests added?  | ✔️
| Breaks BC?    | ❌

## What does this PR do?

Adds `pipe(callable $callback)` to all 7 widgets via `PipeTrait`. Passes the widget through the callback and returns the result, keeping the fluent chain intact.

```php
$tailwindNav = fn(Menu $m) => $m->class('flex space-x-4')->linkClass('px-3 py-2 rounded-md');

Menu::widget()
    ->items($items)
    ->pipe($tailwindNav)
    ->render();
```

Reusable configuration (themes, style presets) can be extracted into callables and composed without subclassing.

No BC break: new method only, added via trait.
