### PR TITLE
Add `filter()` method to `Menu` and `Dropdown`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Enh #114: Add `readonly` to constructor-promoted properties in `Block`, `ContentDecorator`, and `FragmentCache` (@WarLikeLaux)
 - Enh #123: Remove redundant `array_merge()` call with single argument in `Dropdown` (@WarLikeLaux)
 - New #129: Add `id()` method to `Menu` and `Breadcrumbs` widgets (@WarLikeLaux)
+- New #151: Add `filter()` method to `Menu` and `Dropdown` widgets (@WarLikeLaux)
 
 ## 2.1.1 September 23, 2025
 

--- a/docs/guide/en/dropdown.md
+++ b/docs/guide/en/dropdown.md
@@ -58,6 +58,7 @@ Method | Description | Default
 `dividerAttributes(array $valuesMap)` | The HTML attributes for the divider tag | `[]`
 `dividerClass(string $value)` | The CSS class for the divider tag | `dropdown-divider`
 `dividerTag(string $value)` | The tag name for the divider tag | `hr`
+`filter(?Closure $callback)` | The per-item filter callback, or `null` to disable filtering | `null`
 `headerClass(string $value)` | The CSS class for the header tag | `''`
 `headerTag(string $value)` | The tag name for the header tag | `span`
 `id(string $value)` | The ID of the widget | `''`

--- a/docs/guide/en/menu.md
+++ b/docs/guide/en/menu.md
@@ -98,6 +98,7 @@ Method | Description | Default
 `dropdownContainerClass(string $value)` | The CSS class to be appended to the dropdown container | `'dropdown'`
 `dropdownContainerTag(string $value)` | The tag name for the dropdown container | `'li'`
 `dropdownDefinitions(array $valuesMap)` | The config for dropdown widget | `[]`
+`filter(?Closure $callback)` | The per-item filter callback, or `null` to disable filtering | `null`
 `firstItemClass(string $value)` | The CSS class for the first item in the main menu or each submenu | `''`
 `iconContainerAttributes(array $valuesMap)` | The HTML attributes for the icon container | `[]`
 `items(array $value)` | List of menu items | `[]`

--- a/docs/guide/pt-BR/dropdown.md
+++ b/docs/guide/pt-BR/dropdown.md
@@ -58,6 +58,7 @@ Método | Descrição | Padrão
 `dividerAttributes(array $valuesMap)` | Os atributos HTML da tag divisor | `[]`
 `dividerClass(string $value)` | A classe CSS para a tag divisor | `dropdown-divider`
 `dividerTag(string $value)` | O nome da tag do divisor | `hr`
+`filter(?Closure $callback)` | O retorno de chamada de filtro por item, ou `null` para desabilitar a filtragem | `null`
 `headerClass(string $value)` | A classe CSS para a tag de cabeçalho | `''`
 `headerTag(string $value)` | O nome da tag de cabeçalho | `h6`
 `id(string $value)` | O ID do widget | `''`

--- a/docs/guide/pt-BR/menu.md
+++ b/docs/guide/pt-BR/menu.md
@@ -98,6 +98,7 @@ Método | Descrição | Padrão
 `dropdownContainerClass(string $value)` | A classe CSS a ser anexada ao contêiner suspenso | `'dropdown'`
 `dropdownContainerTag(string $value)` | O nome da tag para o contêiner suspenso | `'li'`
 `dropdownDefinitions(array $valuesMap)` | A configuração do widget suspenso | `[]`
+`filter(?Closure $callback)` | O retorno de chamada de filtro por item, ou `null` para desabilitar a filtragem | `null`
 `firstItemClass(string $value)` | A classe CSS do primeiro item do menu principal ou de cada submenu | `null`
 `iconContainerAttributes(array $valuesMap)` | Os atributos HTML para o contêiner de ícones | `[]`
 `items(array $value)` | Lista de itens do menu | `[]`

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Yiisoft\Yii\Widgets;
 
+use Closure;
 use InvalidArgumentException;
 use Yiisoft\Definitions\Exception\CircularReferenceException;
 use Yiisoft\Definitions\Exception\InvalidConfigException;
@@ -15,8 +16,11 @@ use Yiisoft\Html\Tag\Button;
 use Yiisoft\Html\Tag\Span;
 use Yiisoft\Widget\Widget;
 
+use function array_filter;
+use function array_values;
 use function gettype;
 use function implode;
+use function is_array;
 use function str_contains;
 use function trim;
 
@@ -33,6 +37,7 @@ final class Dropdown extends Widget
     private array $dividerAttributes = [];
     private string $dividerClass = 'dropdown-divider';
     private string $dividerTag = 'hr';
+    private ?Closure $filter = null;
     private string $headerClass = '';
     private string $headerTag = 'span';
     private string $id = '';
@@ -161,6 +166,22 @@ final class Dropdown extends Widget
     {
         $new = clone $this;
         $new->dividerTag = $value;
+
+        return $new;
+    }
+
+    /**
+     * Returns a new instance with the specified per-item filter callback.
+     *
+     * The callback receives each raw item array and should return true to keep the item or false to remove it.
+     * It is applied before the normalizer processes items.
+     *
+     * @param Closure|null $callback The callback to apply to each item, or null to disable filtering.
+     */
+    public function filter(?Closure $callback): self
+    {
+        $new = clone $this;
+        $new->filter = $callback;
 
         return $new;
     }
@@ -434,6 +455,16 @@ final class Dropdown extends Widget
      */
     public function render(): string
     {
+        $rawItems = $this->items;
+
+        if ($this->filter !== null) {
+            $filter = $this->filter;
+            $rawItems = array_values(array_filter(
+                $rawItems,
+                fn(mixed $item): bool => !is_array($item) || $filter($item),
+            ));
+        }
+
         /**
          * @psalm-var array<
          *   array-key,
@@ -452,7 +483,7 @@ final class Dropdown extends Widget
          *   }|string
          * > $normalizedItems
          */
-        $normalizedItems = Helper\Normalizer::dropdown($this->items);
+        $normalizedItems = Helper\Normalizer::dropdown($rawItems);
 
         $containerAttributes = $this->containerAttributes;
 

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -18,7 +18,6 @@ use Yiisoft\Widget\Widget;
 
 use function gettype;
 use function implode;
-use function is_array;
 use function str_contains;
 use function trim;
 
@@ -35,7 +34,7 @@ final class Dropdown extends Widget
     private array $dividerAttributes = [];
     private string $dividerClass = 'dropdown-divider';
     private string $dividerTag = 'hr';
-    /** @psalm-var (Closure(array): bool)|null */
+    /** @psalm-var (Closure(array|string): bool)|null */
     private ?Closure $filter = null;
     private string $headerClass = '';
     private string $headerTag = 'span';
@@ -172,12 +171,12 @@ final class Dropdown extends Widget
     /**
      * Returns a new instance with the specified per-item filter callback.
      *
-     * The callback receives each raw item array and should return true to keep the item or false to remove it.
-     * It is applied before the normalizer processes items.
+     * The callback receives each normalized item (an array, or the string `'-'` for a divider) and should return
+     * true to keep the item or false to remove it. It is applied after the items are normalized.
      *
      * @param Closure|null $callback The callback to apply to each item, or null to disable filtering.
      *
-     * @psalm-param (Closure(array): bool)|null $callback
+     * @psalm-param (Closure(array|string): bool)|null $callback
      */
     public function filter(?Closure $callback): self
     {
@@ -457,20 +456,6 @@ final class Dropdown extends Widget
      */
     public function render(): string
     {
-        $rawItems = $this->items;
-
-        if ($this->filter !== null) {
-            $filtered = [];
-
-            foreach ($rawItems as $item) {
-                if (!is_array($item) || ($this->filter)($item)) {
-                    $filtered[] = $item;
-                }
-            }
-
-            $rawItems = $filtered;
-        }
-
         /**
          * @psalm-var array<
          *   array-key,
@@ -489,7 +474,19 @@ final class Dropdown extends Widget
          *   }|string
          * > $normalizedItems
          */
-        $normalizedItems = Helper\Normalizer::dropdown($rawItems);
+        $normalizedItems = Helper\Normalizer::dropdown($this->items);
+
+        if ($this->filter !== null) {
+            $filtered = [];
+
+            foreach ($normalizedItems as $item) {
+                if (($this->filter)($item)) {
+                    $filtered[] = $item;
+                }
+            }
+
+            $normalizedItems = $filtered;
+        }
 
         $containerAttributes = $this->containerAttributes;
 

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -16,8 +16,6 @@ use Yiisoft\Html\Tag\Button;
 use Yiisoft\Html\Tag\Span;
 use Yiisoft\Widget\Widget;
 
-use function array_filter;
-use function array_values;
 use function gettype;
 use function implode;
 use function is_array;
@@ -37,6 +35,7 @@ final class Dropdown extends Widget
     private array $dividerAttributes = [];
     private string $dividerClass = 'dropdown-divider';
     private string $dividerTag = 'hr';
+    /** @psalm-var (Closure(array): bool)|null */
     private ?Closure $filter = null;
     private string $headerClass = '';
     private string $headerTag = 'span';
@@ -177,6 +176,8 @@ final class Dropdown extends Widget
      * It is applied before the normalizer processes items.
      *
      * @param Closure|null $callback The callback to apply to each item, or null to disable filtering.
+     *
+     * @psalm-param (Closure(array): bool)|null $callback
      */
     public function filter(?Closure $callback): self
     {
@@ -459,11 +460,15 @@ final class Dropdown extends Widget
         $rawItems = $this->items;
 
         if ($this->filter !== null) {
-            $filter = $this->filter;
-            $rawItems = array_values(array_filter(
-                $rawItems,
-                fn(mixed $item): bool => !is_array($item) || $filter($item),
-            ));
+            $filtered = [];
+
+            foreach ($rawItems as $item) {
+                if (!is_array($item) || ($this->filter)($item)) {
+                    $filtered[] = $item;
+                }
+            }
+
+            $rawItems = $filtered;
         }
 
         /**

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Yiisoft\Yii\Widgets;
 
+use Closure;
 use InvalidArgumentException;
 use Stringable;
 use Yiisoft\Definitions\Exception\CircularReferenceException;
@@ -13,9 +14,12 @@ use Yiisoft\Factory\NotFoundException;
 use Yiisoft\Html\Html;
 use Yiisoft\Widget\Widget;
 
+use function array_filter;
 use function array_merge;
+use function array_values;
 use function count;
 use function implode;
+use function is_array;
 use function strtr;
 use function trim;
 
@@ -60,6 +64,7 @@ final class Menu extends Widget
     private array $dropdownContainerAttributes = [];
     private string $dropdownContainerTag = 'li';
     private array $dropdownDefinitions = [];
+    private ?Closure $filter = null;
     private string $firstItemClass = '';
     private array $iconContainerAttributes = [];
     private array $items = [];
@@ -309,6 +314,22 @@ final class Menu extends Widget
     }
 
     /**
+     * Returns a new instance with the specified per-item filter callback.
+     *
+     * The callback receives each raw item array and should return true to keep the item or false to remove it.
+     * It is applied before the normalizer processes items.
+     *
+     * @param Closure|null $callback The callback to apply to each item, or null to disable filtering.
+     */
+    public function filter(?Closure $callback): self
+    {
+        $new = clone $this;
+        $new->filter = $callback;
+
+        return $new;
+    }
+
+    /**
      * Returns a new instance with the specified first item CSS class.
      *
      * @param string $value The CSS class that will be assigned to the first item in the main menu or each submenu.
@@ -523,7 +544,17 @@ final class Menu extends Widget
      */
     public function render(): string
     {
-        if ($this->items === []) {
+        $rawItems = $this->items;
+
+        if ($this->filter !== null) {
+            $filter = $this->filter;
+            $rawItems = array_values(array_filter(
+                $rawItems,
+                fn(mixed $item): bool => !is_array($item) || $filter($item),
+            ));
+        }
+
+        if ($rawItems === []) {
             return '';
         }
 
@@ -542,7 +573,7 @@ final class Menu extends Widget
          * > $items
          */
         $items = Helper\Normalizer::menu(
-            $this->items,
+            $rawItems,
             $this->currentPath,
             $this->activateItems,
             $this->iconContainerAttributes,

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -14,9 +14,7 @@ use Yiisoft\Factory\NotFoundException;
 use Yiisoft\Html\Html;
 use Yiisoft\Widget\Widget;
 
-use function array_filter;
 use function array_merge;
-use function array_values;
 use function count;
 use function implode;
 use function is_array;
@@ -64,6 +62,7 @@ final class Menu extends Widget
     private array $dropdownContainerAttributes = [];
     private string $dropdownContainerTag = 'li';
     private array $dropdownDefinitions = [];
+    /** @psalm-var (Closure(array): bool)|null */
     private ?Closure $filter = null;
     private string $firstItemClass = '';
     private array $iconContainerAttributes = [];
@@ -333,6 +332,8 @@ final class Menu extends Widget
      * It is applied before the normalizer processes items.
      *
      * @param Closure|null $callback The callback to apply to each item, or null to disable filtering.
+     *
+     * @psalm-param (Closure(array): bool)|null $callback
      */
     public function filter(?Closure $callback): self
     {
@@ -561,11 +562,15 @@ final class Menu extends Widget
         $rawItems = $this->items;
 
         if ($this->filter !== null) {
-            $filter = $this->filter;
-            $rawItems = array_values(array_filter(
-                $rawItems,
-                fn(mixed $item): bool => !is_array($item) || $filter($item),
-            ));
+            $filtered = [];
+
+            foreach ($rawItems as $item) {
+                if (!is_array($item) || ($this->filter)($item)) {
+                    $filtered[] = $item;
+                }
+            }
+
+            $rawItems = $filtered;
         }
 
         if ($rawItems === []) {

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -17,7 +17,6 @@ use Yiisoft\Widget\Widget;
 use function array_merge;
 use function count;
 use function implode;
-use function is_array;
 use function strtr;
 use function trim;
 
@@ -328,8 +327,8 @@ final class Menu extends Widget
     /**
      * Returns a new instance with the specified per-item filter callback.
      *
-     * The callback receives each raw item array and should return true to keep the item or false to remove it.
-     * It is applied before the normalizer processes items.
+     * The callback receives each normalized item array and should return true to keep the item or false to
+     * remove it. It is applied after the items are normalized.
      *
      * @param Closure|null $callback The callback to apply to each item, or null to disable filtering.
      *
@@ -559,24 +558,6 @@ final class Menu extends Widget
      */
     public function render(): string
     {
-        $rawItems = $this->items;
-
-        if ($this->filter !== null) {
-            $filtered = [];
-
-            foreach ($rawItems as $item) {
-                if (!is_array($item) || ($this->filter)($item)) {
-                    $filtered[] = $item;
-                }
-            }
-
-            $rawItems = $filtered;
-        }
-
-        if ($rawItems === []) {
-            return '';
-        }
-
         /**
          * @psalm-var array<
          *   array-key,
@@ -592,11 +573,27 @@ final class Menu extends Widget
          * > $items
          */
         $items = Helper\Normalizer::menu(
-            $rawItems,
+            $this->items,
             $this->currentPath,
             $this->activateItems,
             $this->iconContainerAttributes,
         );
+
+        if ($this->filter !== null) {
+            $filtered = [];
+
+            foreach ($items as $item) {
+                if (($this->filter)($item)) {
+                    $filtered[] = $item;
+                }
+            }
+
+            $items = $filtered;
+        }
+
+        if ($items === []) {
+            return '';
+        }
 
         return $this->renderMenu($items);
     }

--- a/tests/Dropdown/DropdownTest.php
+++ b/tests/Dropdown/DropdownTest.php
@@ -117,6 +117,44 @@ final class DropdownTest extends TestCase
         );
     }
 
+    public function testFilter(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <div>
+            <li><a aria-current="true" class="active" href="#">Action</a></li>
+            <li><a href="#">Something else here</a></li>
+            <li><hr class="dropdown-divider"></li>
+            <li><a class="disabled" href="#">Separated link</a></li>
+            </div>
+            HTML,
+            Dropdown::widget()
+                ->filter(fn(array $item) => ($item['label'] ?? '') !== 'Another action')
+                ->items($this->items)
+                ->render(),
+        );
+    }
+
+    public function testFilterWithNull(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <div>
+            <li><a aria-current="true" class="active" href="#">Action</a></li>
+            <li><a href="#">Another action</a></li>
+            <li><a href="#">Something else here</a></li>
+            <li><hr class="dropdown-divider"></li>
+            <li><a class="disabled" href="#">Separated link</a></li>
+            </div>
+            HTML,
+            Dropdown::widget()
+                ->filter(fn(array $item) => false)
+                ->filter(null)
+                ->items($this->items)
+                ->render(),
+        );
+    }
+
     public function testItemContainerWithFalse(): void
     {
         Assert::equalsWithoutLE(

--- a/tests/Dropdown/DropdownTest.php
+++ b/tests/Dropdown/DropdownTest.php
@@ -9,6 +9,8 @@ use Yiisoft\Yii\Widgets\Dropdown;
 use Yiisoft\Yii\Widgets\Tests\Support\Assert;
 use Yiisoft\Yii\Widgets\Tests\Support\TestTrait;
 
+use function is_array;
+
 final class DropdownTest extends TestCase
 {
     use TestTrait;
@@ -129,7 +131,7 @@ final class DropdownTest extends TestCase
             </div>
             HTML,
             Dropdown::widget()
-                ->filter(fn(array $item) => ($item['label'] ?? '') !== 'Another action')
+                ->filter(fn(array|string $item) => !is_array($item) || $item['label'] !== 'Another action')
                 ->items($this->items)
                 ->render(),
         );
@@ -148,8 +150,26 @@ final class DropdownTest extends TestCase
             </div>
             HTML,
             Dropdown::widget()
-                ->filter(fn(array $item) => false)
+                ->filter(fn(array|string $item) => false)
                 ->filter(null)
+                ->items($this->items)
+                ->render(),
+        );
+    }
+
+    public function testFilterRemovesStringItems(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <div>
+            <li><a aria-current="page" class="active" href="#">Action</a></li>
+            <li><a href="#">Another action</a></li>
+            <li><a href="#">Something else here</a></li>
+            <li><a aria-disabled="true" class="disabled" href="#">Separated link</a></li>
+            </div>
+            HTML,
+            Dropdown::widget()
+                ->filter(fn(array|string $item) => is_array($item))
                 ->items($this->items)
                 ->render(),
         );

--- a/tests/Dropdown/DropdownTest.php
+++ b/tests/Dropdown/DropdownTest.php
@@ -122,10 +122,10 @@ final class DropdownTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div>
-            <li><a aria-current="true" class="active" href="#">Action</a></li>
+            <li><a aria-current="page" class="active" href="#">Action</a></li>
             <li><a href="#">Something else here</a></li>
             <li><hr class="dropdown-divider"></li>
-            <li><a class="disabled" href="#">Separated link</a></li>
+            <li><a aria-disabled="true" class="disabled" href="#">Separated link</a></li>
             </div>
             HTML,
             Dropdown::widget()
@@ -140,11 +140,11 @@ final class DropdownTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div>
-            <li><a aria-current="true" class="active" href="#">Action</a></li>
+            <li><a aria-current="page" class="active" href="#">Action</a></li>
             <li><a href="#">Another action</a></li>
             <li><a href="#">Something else here</a></li>
             <li><hr class="dropdown-divider"></li>
-            <li><a class="disabled" href="#">Separated link</a></li>
+            <li><a aria-disabled="true" class="disabled" href="#">Separated link</a></li>
             </div>
             HTML,
             Dropdown::widget()

--- a/tests/Dropdown/ImmutableTest.php
+++ b/tests/Dropdown/ImmutableTest.php
@@ -24,6 +24,7 @@ final class ImmutableTest extends TestCase
         $this->assertNotSame($dropdown, $dropdown->dividerAttributes([]));
         $this->assertNotSame($dropdown, $dropdown->dividerClass(''));
         $this->assertNotSame($dropdown, $dropdown->dividerTag(''));
+        $this->assertNotSame($dropdown, $dropdown->filter(fn(array $item) => true));
         $this->assertNotSame($dropdown, $dropdown->headerClass(''));
         $this->assertNotSame($dropdown, $dropdown->headerTag(''));
         $this->assertNotSame($dropdown, $dropdown->id(''));

--- a/tests/Dropdown/ImmutableTest.php
+++ b/tests/Dropdown/ImmutableTest.php
@@ -24,7 +24,7 @@ final class ImmutableTest extends TestCase
         $this->assertNotSame($dropdown, $dropdown->dividerAttributes([]));
         $this->assertNotSame($dropdown, $dropdown->dividerClass(''));
         $this->assertNotSame($dropdown, $dropdown->dividerTag(''));
-        $this->assertNotSame($dropdown, $dropdown->filter(fn(array $item) => true));
+        $this->assertNotSame($dropdown, $dropdown->filter(fn(array|string $item) => true));
         $this->assertNotSame($dropdown, $dropdown->headerClass(''));
         $this->assertNotSame($dropdown, $dropdown->headerTag(''));
         $this->assertNotSame($dropdown, $dropdown->id(''));

--- a/tests/Menu/ImmutableTest.php
+++ b/tests/Menu/ImmutableTest.php
@@ -33,6 +33,7 @@ final class ImmutableTest extends TestCase
         $this->assertNotSame($menu, $menu->dropdownContainerClass(''));
         $this->assertNotSame($menu, $menu->dropdownContainerTag('div'));
         $this->assertNotSame($menu, $menu->dropdownDefinitions([]));
+        $this->assertNotSame($menu, $menu->filter(fn(array $item) => true));
         $this->assertNotSame($menu, $menu->firstItemClass(''));
         $this->assertNotSame($menu, $menu->iconContainerAttributes([]));
         $this->assertNotSame($menu, $menu->id('test'));

--- a/tests/Menu/MenuTest.php
+++ b/tests/Menu/MenuTest.php
@@ -337,6 +337,49 @@ final class MenuTest extends TestCase
         );
     }
 
+    public function testFilter(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <ul>
+            <li><a href="/active">Active</a></li>
+            <li><a href="#">Link</a></li>
+            </ul>
+            HTML,
+            Menu::widget()
+                ->filter(fn(array $item) => ($item['link'] ?? '') !== '#' || ($item['label'] ?? '') === 'Link')
+                ->items($this->itemsWithOptions)
+                ->render(),
+        );
+    }
+
+    public function testFilterRemovesAllItems(): void
+    {
+        $this->assertSame(
+            '',
+            Menu::widget()
+                ->filter(fn(array $item) => false)
+                ->items($this->items)
+                ->render(),
+        );
+    }
+
+    public function testFilterWithNull(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <ul>
+            <li><a href="/path">item</a></li>
+            </ul>
+            HTML,
+            Menu::widget()
+                ->filter(fn(array $item) => false)
+                ->filter(null)
+                ->items($this->items)
+                ->render(),
+        );
+    }
+
     public function testFirstItemCssClass(): void
     {
         Assert::equalsWithoutLE(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Docs added?   | ❌
| Tests added?  | ✔️
| Breaks BC?    | ❌

## What does this PR do?

Adds `filter()` method to `Menu` and `Dropdown` for removing items by callback before normalization.

The callback receives each raw item array and returns `true` to keep or `false` to remove. Applied before the normalizer processes items. Default is `null` (no filtering). Only array items are filtered. String items (dividers) pass through unchanged.

### Use cases

Permission-based filtering in a fluent chain:

```php
Menu::widget()
    ->filter(fn(array $item) => $user->can($item['permission'] ?? 'view'))
    ->items($items)
    ->render();
```

Conditional item removal without pre-processing the array:

```php
Dropdown::widget()
    ->filter(fn(array $item) => !($item['disabled'] ?? false))
    ->items($items)
    ->render();
```

### BC

No BC break: new optional method, default is `null` (no filtering). Existing code unaffected.
