### PR TITLE
Add `addItem()` and `prependItem()` to `Menu` and `Dropdown`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Enh #114: Add `readonly` to constructor-promoted properties in `Block`, `ContentDecorator`, and `FragmentCache` (@WarLikeLaux)
 - Enh #123: Remove redundant `array_merge()` call with single argument in `Dropdown` (@WarLikeLaux)
 - New #129: Add `id()` method to `Menu` and `Breadcrumbs` widgets (@WarLikeLaux)
+- New #152: Add `addItem()` and `prependItem()` methods to `Menu` and `Dropdown` (@WarLikeLaux)
 
 ## 2.1.1 September 23, 2025
 

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -15,6 +15,7 @@ use Yiisoft\Html\Tag\Button;
 use Yiisoft\Html\Tag\Span;
 use Yiisoft\Widget\Widget;
 
+use function array_unshift;
 use function gettype;
 use function implode;
 use function str_contains;
@@ -58,6 +59,21 @@ final class Dropdown extends Widget
     {
         $new = clone $this;
         $new->activeClass = $value;
+
+        return $new;
+    }
+
+    /**
+     * Returns a new instance with the specified item appended to the list of items.
+     *
+     * Unlike {@see items()}, which replaces the entire list, this method adds a single item to the end.
+     *
+     * @param array $item The item to append.
+     */
+    public function addItem(array $item): self
+    {
+        $new = clone $this;
+        $new->items[] = $item;
 
         return $new;
     }
@@ -346,6 +362,21 @@ final class Dropdown extends Widget
     {
         $new = clone $this;
         $new->itemsContainerTag = $value;
+
+        return $new;
+    }
+
+    /**
+     * Returns a new instance with the specified item prepended to the list of items.
+     *
+     * Unlike {@see items()}, which replaces the entire list, this method adds a single item to the beginning.
+     *
+     * @param array $item The item to prepend.
+     */
+    public function prependItem(array $item): self
+    {
+        $new = clone $this;
+        array_unshift($new->items, $item);
 
         return $new;
     }

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -14,6 +14,7 @@ use Yiisoft\Html\Html;
 use Yiisoft\Widget\Widget;
 
 use function array_merge;
+use function array_unshift;
 use function count;
 use function implode;
 use function strtr;
@@ -96,6 +97,21 @@ final class Menu extends Widget
     {
         $new = clone $this;
         $new->activeClass = $value;
+
+        return $new;
+    }
+
+    /**
+     * Returns a new instance with the specified item appended to the list of items.
+     *
+     * Unlike {@see items()}, which replaces the entire list, this method adds a single item to the end.
+     *
+     * @param array $item The item to append.
+     */
+    public function addItem(array $item): self
+    {
+        $new = clone $this;
+        $new->items[] = $item;
 
         return $new;
     }
@@ -483,6 +499,21 @@ final class Menu extends Widget
     {
         $new = clone $this;
         $new->linkTag = $value;
+
+        return $new;
+    }
+
+    /**
+     * Returns a new instance with the specified item prepended to the list of items.
+     *
+     * Unlike {@see items()}, which replaces the entire list, this method adds a single item to the beginning.
+     *
+     * @param array $item The item to prepend.
+     */
+    public function prependItem(array $item): self
+    {
+        $new = clone $this;
+        array_unshift($new->items, $item);
 
         return $new;
     }

--- a/tests/Dropdown/DropdownTest.php
+++ b/tests/Dropdown/DropdownTest.php
@@ -37,6 +37,40 @@ final class DropdownTest extends TestCase
         );
     }
 
+    public function testAddItem(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <div>
+            <li><a aria-current="true" class="active" href="#">Action</a></li>
+            <li><a href="#">Another action</a></li>
+            <li><a href="#">Something else here</a></li>
+            <li><hr class="dropdown-divider"></li>
+            <li><a class="disabled" href="#">Separated link</a></li>
+            <li><a href="/new">New item</a></li>
+            </div>
+            HTML,
+            Dropdown::widget()
+                ->items($this->items)
+                ->addItem(['label' => 'New item', 'link' => '/new'])
+                ->render(),
+        );
+    }
+
+    public function testAddItemToEmptyItems(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <div>
+            <li><a href="/path">item</a></li>
+            </div>
+            HTML,
+            Dropdown::widget()
+                ->addItem(['label' => 'item', 'link' => '/path'])
+                ->render(),
+        );
+    }
+
     public function testContainerAttributes(): void
     {
         Assert::equalsWithoutLE(
@@ -426,6 +460,40 @@ final class DropdownTest extends TestCase
             ->render();
 
         $this->assertSame(1, substr_count($html, '<button'));
+    }
+
+    public function testPrependItem(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <div>
+            <li><a href="/new">New item</a></li>
+            <li><a aria-current="true" class="active" href="#">Action</a></li>
+            <li><a href="#">Another action</a></li>
+            <li><a href="#">Something else here</a></li>
+            <li><hr class="dropdown-divider"></li>
+            <li><a class="disabled" href="#">Separated link</a></li>
+            </div>
+            HTML,
+            Dropdown::widget()
+                ->items($this->items)
+                ->prependItem(['label' => 'New item', 'link' => '/new'])
+                ->render(),
+        );
+    }
+
+    public function testPrependItemToEmptyItems(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <div>
+            <li><a href="/path">item</a></li>
+            </div>
+            HTML,
+            Dropdown::widget()
+                ->prependItem(['label' => 'item', 'link' => '/path'])
+                ->render(),
+        );
     }
 
     public function testItemHeaderAttributes(): void

--- a/tests/Dropdown/ImmutableTest.php
+++ b/tests/Dropdown/ImmutableTest.php
@@ -16,6 +16,7 @@ final class ImmutableTest extends TestCase
     {
         $dropdown = Dropdown::widget();
         $this->assertNotSame($dropdown, $dropdown->activeClass(''));
+        $this->assertNotSame($dropdown, $dropdown->addItem([]));
         $this->assertNotSame($dropdown, $dropdown->container(false));
         $this->assertNotSame($dropdown, $dropdown->containerAttributes([]));
         $this->assertNotSame($dropdown, $dropdown->containerClass(''));
@@ -37,6 +38,7 @@ final class ImmutableTest extends TestCase
         $this->assertNotSame($dropdown, $dropdown->itemsContainerAttributes([]));
         $this->assertNotSame($dropdown, $dropdown->itemsContainerClass(''));
         $this->assertNotSame($dropdown, $dropdown->itemsContainerTag(''));
+        $this->assertNotSame($dropdown, $dropdown->prependItem([]));
         $this->assertNotSame($dropdown, $dropdown->splitButtonAttributes([]));
         $this->assertNotSame($dropdown, $dropdown->splitButtonClass(''));
         $this->assertNotSame($dropdown, $dropdown->splitButtonSpanClass(''));

--- a/tests/Menu/ImmutableTest.php
+++ b/tests/Menu/ImmutableTest.php
@@ -21,6 +21,7 @@ final class ImmutableTest extends TestCase
         $this->assertNotSame($menu, $menu->afterContent(''));
         $this->assertNotSame($menu, $menu->afterTag(''));
         $this->assertNotSame($menu, $menu->activeClass(''));
+        $this->assertNotSame($menu, $menu->addItem([]));
         $this->assertNotSame($menu, $menu->attributes([]));
         $this->assertNotSame($menu, $menu->beforeAttributes([]));
         $this->assertNotSame($menu, $menu->beforeClass(''));
@@ -45,6 +46,7 @@ final class ImmutableTest extends TestCase
         $this->assertNotSame($menu, $menu->linkAttributes([]));
         $this->assertNotSame($menu, $menu->linkClass(''));
         $this->assertNotSame($menu, $menu->linkTag(''));
+        $this->assertNotSame($menu, $menu->prependItem([]));
         $this->assertNotSame($menu, $menu->tagName(''));
         $this->assertNotSame($menu, $menu->template(''));
     }

--- a/tests/Menu/MenuTest.php
+++ b/tests/Menu/MenuTest.php
@@ -49,6 +49,36 @@ final class MenuTest extends TestCase
         );
     }
 
+    public function testAddItem(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <ul>
+            <li><a href="/path">item</a></li>
+            <li><a href="/other">other</a></li>
+            </ul>
+            HTML,
+            Menu::widget()
+                ->items($this->items)
+                ->addItem(['label' => 'other', 'link' => '/other'])
+                ->render(),
+        );
+    }
+
+    public function testAddItemToEmptyItems(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <ul>
+            <li><a href="/path">item</a></li>
+            </ul>
+            HTML,
+            Menu::widget()
+                ->addItem(['label' => 'item', 'link' => '/path'])
+                ->render(),
+        );
+    }
+
     public function testAfter(): void
     {
         Assert::equalsWithoutLE(
@@ -636,6 +666,36 @@ final class MenuTest extends TestCase
             </ul>
             HTML,
             Menu::widget()->linkClass('test-class')->items($this->itemsWithOptions)->render(),
+        );
+    }
+
+    public function testPrependItem(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <ul>
+            <li><a href="/other">other</a></li>
+            <li><a href="/path">item</a></li>
+            </ul>
+            HTML,
+            Menu::widget()
+                ->items($this->items)
+                ->prependItem(['label' => 'other', 'link' => '/other'])
+                ->render(),
+        );
+    }
+
+    public function testPrependItemToEmptyItems(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <ul>
+            <li><a href="/path">item</a></li>
+            </ul>
+            HTML,
+            Menu::widget()
+                ->prependItem(['label' => 'item', 'link' => '/path'])
+                ->render(),
         );
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Docs added?   | ❌
| Tests added?  | ✔️
| Breaks BC?    | ❌

## What does this PR do?

Adds `addItem()` and `prependItem()` methods to `Menu` and `Dropdown` widgets.

### Use case

When `Menu` is preconfigured via DI container, a view cannot add a context-specific item. `items()` replaces the entire array, and there is no getter to read the current list. `addItem()` appends to the end, `prependItem()` inserts at the beginning. Both are immutable (clone + modification).

```php
// DI config sets base items, view adds context-specific ones
$menu = $menu
    ->prependItem(['label' => 'Home', 'link' => '/'])
    ->addItem(['label' => 'Logout', 'link' => '/logout']);
```

No BC break: new methods only, no changes to existing signatures.
