### PR TITLE
Add `toggleContent()` method to `Dropdown`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Enh #114: Add `readonly` to constructor-promoted properties in `Block`, `ContentDecorator`, and `FragmentCache` (@WarLikeLaux)
 - Enh #123: Remove redundant `array_merge()` call with single argument in `Dropdown` (@WarLikeLaux)
 - New #129: Add `id()` method to `Menu` and `Breadcrumbs` widgets (@WarLikeLaux)
+- New #153: Add `toggleContent()` method to `Dropdown` to allow custom HTML content in the toggle button (@WarLikeLaux)
 
 ## 2.1.1 September 23, 2025
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,11 @@
 - New #126: Add `Menu::dropdownContainerAttributes()` method (@WarLikeLaux)
 - Bug #127: Fix `encode` key leaking into HTML attributes in `Breadcrumbs::renderItem()` (@WarLikeLaux)
 - New #129: Add `id()` method to `Menu` and `Breadcrumbs` widgets (@WarLikeLaux)
-- New #153: Add `toggleContent()` method to `Dropdown` to allow custom HTML content in the toggle button (@WarLikeLaux)
 - New #115: Add container wrapper and JSON-LD structured data to `Breadcrumbs` widget (@WarLikeLaux, @vjik)
 - Bug #118: Add missing ARIA attributes to `Dropdown`, `Menu`, and `Alert` (@WarLikeLaux)
 - Enh #155: Add `url` as alias for `link` in `Menu` and `Dropdown` items (@WarLikeLaux)
 - Enh #157: Improve psalm type annotations (@Tigrov)
+- New #153: Add `toggleContent()` method to `Dropdown` to allow custom HTML content in the toggle button (@WarLikeLaux)
 
 ## 2.1.1 September 23, 2025
 

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Yiisoft\Yii\Widgets;
 
 use InvalidArgumentException;
+use Stringable;
 use Yiisoft\Definitions\Exception\CircularReferenceException;
 use Yiisoft\Definitions\Exception\InvalidConfigException;
 use Yiisoft\Definitions\Exception\NotInstantiableException;
@@ -47,6 +48,7 @@ final class Dropdown extends Widget
     private array $splitButtonAttributes = [];
     private array $splitButtonSpanAttributes = [];
     private array $toggleAttributes = [];
+    private string|Stringable $toggleContent = '';
     private string $toggleType = 'button';
 
     /**
@@ -416,6 +418,22 @@ final class Dropdown extends Widget
     }
 
     /**
+     * Returns a new instance with the specified toggle content.
+     *
+     * If set, the toggle button will render this content instead of the item label.
+     * This is useful when the toggle should display an icon, avatar, or any other custom HTML.
+     *
+     * @param string|Stringable $value The toggle content.
+     */
+    public function toggleContent(string|Stringable $value): self
+    {
+        $new = clone $this;
+        $new->toggleContent = $value;
+
+        return $new;
+    }
+
+    /**
      * Returns a new instance with the specified toggle type, if `button` the toggle will be a button, otherwise a
      * `a` tag will be used.
      *
@@ -713,24 +731,26 @@ final class Dropdown extends Widget
             $toggleAttributes['id'] = $this->id;
         }
 
+        $content = (string) $this->toggleContent !== '' ? $this->toggleContent : $label;
+
         return match ($this->toggleType) {
-            'link' => $this->renderToggleLink($label, $link, $toggleAttributes),
-            'split' => $this->renderToggleSplit($label, $toggleAttributes),
-            default => $this->renderToggleButton($label, $toggleAttributes),
+            'link' => $this->renderToggleLink($content, $link, $toggleAttributes),
+            'split' => $this->renderToggleSplit($content, $toggleAttributes),
+            default => $this->renderToggleButton($content, $toggleAttributes),
         };
     }
 
-    private function renderToggleButton(string $label, array $toggleAttributes = []): string
+    private function renderToggleButton(string|Stringable $label, array $toggleAttributes = []): string
     {
         return (new Button())->attributes($toggleAttributes)->content($label)->type('button')->render();
     }
 
-    private function renderToggleLink(string $label, string $link, array $toggleAttributes = []): string
+    private function renderToggleLink(string|Stringable $label, string $link, array $toggleAttributes = []): string
     {
         return (new A())->attributes($toggleAttributes)->content($label)->href($link)->render();
     }
 
-    private function renderToggleSplit(string $label, array $toggleAttributes = []): string
+    private function renderToggleSplit(string|Stringable $label, array $toggleAttributes = []): string
     {
         return (new Button())
             ->attributes($toggleAttributes)

--- a/tests/Dropdown/DropdownTest.php
+++ b/tests/Dropdown/DropdownTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Yiisoft\Yii\Widgets\Tests\Dropdown;
 
 use PHPUnit\Framework\TestCase;
+use Yiisoft\Html\Tag\Span;
 use Yiisoft\Yii\Widgets\Dropdown;
 use Yiisoft\Yii\Widgets\Tests\Support\Assert;
 use Yiisoft\Yii\Widgets\Tests\Support\TestTrait;
@@ -494,5 +495,57 @@ final class DropdownTest extends TestCase
             ->render();
 
         $this->assertStringContainsString('data-custom="value"', $html);
+    }
+
+    public function testToggleContent(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <div>
+            <button type="button">Custom toggle</button>
+            <ul>
+            <li><a href="#">Action</a></li>
+            </ul>
+            </div>
+            HTML,
+            Dropdown::widget()
+                ->toggleContent('Custom toggle')
+                ->items([
+                    [
+                        'label' => 'Dropdown',
+                        'link' => '#',
+                        'items' => [
+                            ['label' => 'Action', 'link' => '#'],
+                        ],
+                    ],
+                ])
+                ->render(),
+        );
+    }
+
+    public function testToggleContentWithStringable(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <div>
+            <button type="button"><span>🔔</span></button>
+            <ul>
+            <li><a href="#">Action</a></li>
+            </ul>
+            </div>
+            HTML,
+            Dropdown::widget()
+                ->toggleContent((new Span())->content('🔔'))
+                ->items([
+                    [
+                        'label' => 'Dropdown',
+                        'link' => '#',
+                        'items' => [
+                            ['label' => 'Action', 'link' => '#'],
+                        ],
+                    ],
+                ])
+                ->render(),
+        );
     }
 }

--- a/tests/Dropdown/DropdownTest.php
+++ b/tests/Dropdown/DropdownTest.php
@@ -736,6 +736,39 @@ final class DropdownTest extends TestCase
         );
     }
 
+    public function testToggleContentDoesNotReplaceNestedDropdownLabels(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <div>
+            <button id="dropdown-1" type="button"><span class="avatar">SL</span></button>
+            <ul aria-labelledby="dropdown-1">
+            <button id="dropdown-2" type="button">Settings</button>
+            <ul aria-labelledby="dropdown-2">
+            <li><a href="/profile">Profile</a></li>
+            </ul>
+            </ul>
+            </div>
+            HTML,
+            Dropdown::widget()
+                ->toggleContent((new Span())->attributes(['class' => 'avatar'])->content('SL'))
+                ->items([
+                    [
+                        'label' => 'Account',
+                        'items' => [
+                            [
+                                'label' => 'Settings',
+                                'items' => [
+                                    ['label' => 'Profile', 'link' => '/profile'],
+                                ],
+                            ],
+                        ],
+                    ],
+                ])
+                ->render(),
+        );
+    }
+
     public function testUrlAsLinkAlias(): void
     {
         Assert::equalsWithoutLE(

--- a/tests/Dropdown/ImmutableTest.php
+++ b/tests/Dropdown/ImmutableTest.php
@@ -42,6 +42,7 @@ final class ImmutableTest extends TestCase
         $this->assertNotSame($dropdown, $dropdown->splitButtonSpanClass(''));
         $this->assertNotSame($dropdown, $dropdown->toggleAttributes([]));
         $this->assertNotSame($dropdown, $dropdown->toggleClass(''));
+        $this->assertNotSame($dropdown, $dropdown->toggleContent(''));
         $this->assertNotSame($dropdown, $dropdown->toggleType(''));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Docs added?   | ❌
| Tests added?  | ✔️
| Breaks BC?    | ❌

## What does this PR do?

Adds `toggleContent(string|Stringable $value)` method to `Dropdown` that sets custom content for the toggle button instead of using the item label.

### Use cases

When the dropdown toggle should display something other than plain text - an icon, avatar image, or any `Stringable` widget:

```php
// Icon toggle
Dropdown::widget()
    ->toggleContent((new Span())->content('🔔'))
    ->toggleAttributes(['class' => 'btn btn-light', 'data-bs-toggle' => 'dropdown'])
    ->items([...])

// Plain text override
Dropdown::widget()
    ->toggleContent('Menu')
    ->items([...])
```

Without `toggleContent()`, the toggle button renders the item's `label` as before.

No BC break: new optional method, existing code unaffected.
