### PR TITLE
Add `url` as alias for `link` in `Menu` and `Dropdown` items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - Enh #114: Add `readonly` to constructor-promoted properties in `Block`, `ContentDecorator`, and `FragmentCache` (@WarLikeLaux)
 - Enh #123: Remove redundant `array_merge()` call with single argument in `Dropdown` (@WarLikeLaux)
 - New #129: Add `id()` method to `Menu` and `Breadcrumbs` widgets (@WarLikeLaux)
-- Enh: Add `url` as alias for `link` in `Menu` and `Dropdown` items (@WarLikeLaux)
+- Enh #155: Add `url` as alias for `link` in `Menu` and `Dropdown` items (@WarLikeLaux)
 
 ## 2.1.1 September 23, 2025
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Enh #114: Add `readonly` to constructor-promoted properties in `Block`, `ContentDecorator`, and `FragmentCache` (@WarLikeLaux)
 - Enh #123: Remove redundant `array_merge()` call with single argument in `Dropdown` (@WarLikeLaux)
 - New #129: Add `id()` method to `Menu` and `Breadcrumbs` widgets (@WarLikeLaux)
+- Enh: Add `url` as alias for `link` in `Menu` and `Dropdown` items (@WarLikeLaux)
 
 ## 2.1.1 September 23, 2025
 

--- a/docs/guide/en/dropdown.md
+++ b/docs/guide/en/dropdown.md
@@ -98,3 +98,6 @@ Method | Description | Default
         'visible' => true,
     ],
 ]
+```
+
+> `url` can be used as a fallback alias for `link`. If both are present, `link` takes priority.

--- a/docs/guide/en/menu.md
+++ b/docs/guide/en/menu.md
@@ -132,3 +132,5 @@ Method | Description | Default
     ],
 ]
 ```
+
+> `url` can be used as a fallback alias for `link`. If both are present, `link` takes priority.

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -292,7 +292,8 @@ final class Dropdown extends Widget
      * - enclose: bool, whether the item should be enclosed by a `<li>` tag or not. For default `enclose` is true.
      * - encode: bool, whether the label should be HTML encoded or not. For default `encodeLabel` is true.
      * - headerAttributes: array, HTML attributes to be rendered in the item header.
-     * - link: string, the item's href. Defaults to "#". For default `link` is "#".
+     * - link: string, the item's href. Defaults to "#". For default `link` is "#". `url` can be used as a fallback
+     *   alias when `link` is not set.
      * - linkAttributes: array, the HTML attributes of the item's link. For default `linkAttributes` is `[]`.
      * - icon: string, the item's icon. For default `icon` is ``.
      * - iconAttributes: array, the HTML attributes of the item's icon. For default `iconAttributes` is `[]`.

--- a/src/Helper/Normalizer.php
+++ b/src/Helper/Normalizer.php
@@ -219,7 +219,15 @@ final class Normalizer
 
     private static function link(array $item, string $defaultValue = ''): string
     {
-        return array_key_exists('link', $item) && is_string($item['link']) ? $item['link'] : $defaultValue;
+        if (array_key_exists('link', $item) && is_string($item['link'])) {
+            return $item['link'];
+        }
+
+        if (array_key_exists('url', $item) && is_string($item['url'])) {
+            return $item['url'];
+        }
+
+        return $defaultValue;
     }
 
     private static function linkAttributes(array $item): array

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -364,7 +364,8 @@ final class Menu extends Widget
      * - encode: bool, whether the label should be HTML encoded or not. For default `encodeLabel` is true.
      * - items: array, optional, the item's submenu items. The structure is the same as for `items` option.
      * - itemsContainerAttributes: array, optional, the HTML attributes for the item's submenu container.
-     * - link: string, the item's href. Defaults to "#". For default `link` is "#".
+     * - link: string, the item's href. Defaults to "#". For default `link` is "#". `url` can be used as a fallback
+     *   alias when `link` is not set.
      * - linkAttributes: array, the HTML attributes of the item's link. For default `linkAttributes` is `[]`.
      * - icon: string, the item's icon. For default is ``.
      * - iconAttributes: array, the HTML attributes of the item's icon. For default `iconAttributes` is `[]`.

--- a/tests/Dropdown/DropdownTest.php
+++ b/tests/Dropdown/DropdownTest.php
@@ -495,4 +495,28 @@ final class DropdownTest extends TestCase
 
         $this->assertStringContainsString('data-custom="value"', $html);
     }
+
+    public function testUrlAsLinkAlias(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <div>
+            <li><a href="#">Action</a></li>
+            </div>
+            HTML,
+            Dropdown::widget()->items([['label' => 'Action', 'url' => '#']])->render(),
+        );
+    }
+
+    public function testLinkTakesPriorityOverUrl(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <div>
+            <li><a href="/link">Action</a></li>
+            </div>
+            HTML,
+            Dropdown::widget()->items([['label' => 'Action', 'link' => '/link', 'url' => '/url']])->render(),
+        );
+    }
 }

--- a/tests/Menu/MenuTest.php
+++ b/tests/Menu/MenuTest.php
@@ -726,6 +726,30 @@ final class MenuTest extends TestCase
         );
     }
 
+    public function testUrlAsLinkAlias(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <ul>
+            <li><a href="/path">item</a></li>
+            </ul>
+            HTML,
+            Menu::widget()->items([['label' => 'item', 'url' => '/path']])->render(),
+        );
+    }
+
+    public function testLinkTakesPriorityOverUrl(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <ul>
+            <li><a href="/link">item</a></li>
+            </ul>
+            HTML,
+            Menu::widget()->items([['label' => 'item', 'link' => '/link', 'url' => '/url']])->render(),
+        );
+    }
+
     public function testItemLinkAttributesOverrideWidgetLinkAttributes(): void
     {
         Assert::equalsWithoutLE(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Docs added?   | ❌
| Tests added?  | ✔️
| Breaks BC?    | ❌

## What does this PR do?

Adds `url` as a fallback alias for `link` in `Menu` and `Dropdown` item arrays, so that items written for `Breadcrumbs` (which uses `url`) work in `Menu`/`Dropdown` without changes.

`Normalizer::link()` now checks `$item['url']` when `$item['link']` is not set. `link` takes priority when both keys are present.

No BC break: existing items with `link` are unaffected, `url` is only used as a fallback.
