### PR TITLE
Fix #159: Fix double-encoding of toggle and nested item labels in `Dropdown`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Bug #118: Add missing ARIA attributes to `Dropdown`, `Menu`, and `Alert` (@WarLikeLaux)
 - Enh #155: Add `url` as alias for `link` in `Menu` and `Dropdown` items (@WarLikeLaux)
 - Enh #157: Improve psalm type annotations (@Tigrov)
+- Bug #159: Fix double-encoding of toggle and nested item labels in `Dropdown` (@WarLikeLaux)
 
 ## 2.1.1 September 23, 2025
 

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -435,6 +435,19 @@ final class Dropdown extends Widget
      */
     public function render(): string
     {
+        return $this->renderToContainer(Helper\Normalizer::dropdown($this->items));
+    }
+
+    /**
+     * Renders already normalized items into the container. Sub-dropdowns reuse this directly so the items are
+     * normalized once, by the top-level {@see render()}, and not again per nesting level.
+     *
+     * @throws CircularReferenceException|InvalidConfigException|NotFoundException|NotInstantiableException
+     */
+    private function renderToContainer(array $normalizedItems): string
+    {
+        $containerAttributes = $this->containerAttributes;
+
         /**
          * @psalm-var array<
          *   array-key,
@@ -453,10 +466,6 @@ final class Dropdown extends Widget
          *   }|string
          * > $normalizedItems
          */
-        $normalizedItems = Helper\Normalizer::dropdown($this->items);
-
-        $containerAttributes = $this->containerAttributes;
-
         $items = $this->renderItems($normalizedItems) . PHP_EOL;
 
         if (trim($items) === '') {
@@ -507,12 +516,11 @@ final class Dropdown extends Widget
             ->itemClass($this->itemClass)
             ->itemContainerAttributes($this->itemContainerAttributes)
             ->itemContainerTag($this->itemContainerTag)
-            ->items($items)
             ->itemsContainerAttributes($this->itemsContainerAttributes)
             ->itemTag($this->itemTag)
             ->toggleAttributes($this->toggleAttributes)
             ->toggleType($this->toggleType)
-            ->render();
+            ->renderToContainer($items);
     }
 
     private function renderHeader(string $label, array $headerAttributes = []): string

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -724,25 +724,30 @@ final class Dropdown extends Widget
 
     private function renderToggleButton(string $label, array $toggleAttributes = []): string
     {
-        return (new Button())->attributes($toggleAttributes)->content($label)->type('button')->render();
+        return (new Button())->attributes($toggleAttributes)->content($label)->encode(false)->type('button')->render();
     }
 
     private function renderToggleLink(string $label, string $link, array $toggleAttributes = []): string
     {
-        return (new A())->attributes($toggleAttributes)->content($label)->href($link)->render();
+        return (new A())->attributes($toggleAttributes)->content($label)->encode(false)->href($link)->render();
     }
 
     private function renderToggleSplit(string $label, array $toggleAttributes = []): string
     {
         return (new Button())
             ->attributes($toggleAttributes)
-            ->content((new Span())->attributes($this->splitButtonSpanAttributes)->content($label))
+            ->content((new Span())->attributes($this->splitButtonSpanAttributes)->content($label)->encode(false))
             ->type('button')
             ->render();
     }
 
     private function renderToggleSplitButton(string $label): string
     {
-        return (new Button())->attributes($this->splitButtonAttributes)->content($label)->type('button')->render();
+        return (new Button())
+            ->attributes($this->splitButtonAttributes)
+            ->content($label)
+            ->encode(false)
+            ->type('button')
+            ->render();
     }
 }

--- a/src/Helper/Normalizer.php
+++ b/src/Helper/Normalizer.php
@@ -54,7 +54,7 @@ final class Normalizer
                 $items[$i]['visible'] = self::visible($child);
 
                 if (isset($child['items']) && is_array($child['items'])) {
-                    $items[$i]['items'] = self::dropdown($child['items']);
+                    $items[$i]['items'] = $child['items'];
                 } else {
                     $items[$i]['items'] = [];
                 }

--- a/src/Helper/Normalizer.php
+++ b/src/Helper/Normalizer.php
@@ -54,7 +54,7 @@ final class Normalizer
                 $items[$i]['visible'] = self::visible($child);
 
                 if (isset($child['items']) && is_array($child['items'])) {
-                    $items[$i]['items'] = $child['items'];
+                    $items[$i]['items'] = self::dropdown($child['items']);
                 } else {
                     $items[$i]['items'] = [];
                 }

--- a/tests/Dropdown/DropdownTest.php
+++ b/tests/Dropdown/DropdownTest.php
@@ -327,6 +327,86 @@ final class DropdownTest extends TestCase
         );
     }
 
+    public function testSubDropdownIconsAreNotDoubleEncoded(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <div>
+            <button type="button"><span><i class="bi bi-star">star</i></span>Parent</button>
+            <ul>
+            <li><a href="#"><span><i class="bi bi-house">house</i></span>Child</a></li>
+            </ul>
+            </div>
+            HTML,
+            Dropdown::widget()
+                ->items([
+                    [
+                        'label' => 'Parent',
+                        'link' => '#',
+                        'icon' => 'star',
+                        'iconClass' => 'bi bi-star',
+                        'items' => [
+                            ['label' => 'Child', 'link' => '#', 'icon' => 'house', 'iconClass' => 'bi bi-house'],
+                        ],
+                    ],
+                ])
+                ->render(),
+        );
+    }
+
+    public function testToggleLinkIconIsNotDoubleEncoded(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <div>
+            <a href="#"><span><i class="bi bi-star">star</i></span>Parent</a>
+            <ul>
+            <li><a href="#">Child</a></li>
+            </ul>
+            </div>
+            HTML,
+            Dropdown::widget()
+                ->toggleType('link')
+                ->items([
+                    [
+                        'label' => 'Parent',
+                        'link' => '#',
+                        'icon' => 'star',
+                        'iconClass' => 'bi bi-star',
+                        'items' => [['label' => 'Child', 'link' => '#']],
+                    ],
+                ])
+                ->render(),
+        );
+    }
+
+    public function testToggleSplitIconIsNotDoubleEncoded(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <div>
+            <button type="button"><span><i class="bi bi-star">star</i></span>Parent</button>
+            <button type="button"><span><span><i class="bi bi-star">star</i></span>Parent</span></button>
+            <ul>
+            <li><a href="#">Child</a></li>
+            </ul>
+            </div>
+            HTML,
+            Dropdown::widget()
+                ->toggleType('split')
+                ->items([
+                    [
+                        'label' => 'Parent',
+                        'link' => '#',
+                        'icon' => 'star',
+                        'iconClass' => 'bi bi-star',
+                        'items' => [['label' => 'Child', 'link' => '#']],
+                    ],
+                ])
+                ->render(),
+        );
+    }
+
     public function testItemsLinkAttributes(): void
     {
         Assert::equalsWithoutLE(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Tests added?  | ✔️
| Breaks BC?    | ❌

## What does this PR do?

Fixes labels being HTML-encoded twice in a `Dropdown` that has sub-items. An item icon like `<span><i class="bi bi-star"></i></span>` came out as `&lt;span&gt;...`, and a plain label like `A & B` came out as `A &amp;amp; B`.

There were two separate causes. The parent toggle (`renderToggleButton()`, `renderToggleLink()`, `renderToggleSplit()`, `renderToggleSplitButton()`) rendered the label without `encode(false)`, so the already-rendered label from the normalizer got encoded again - leaf items already use `encode(false)`, the toggles didn't. And sub-dropdowns were rendered by spinning up a fresh `Dropdown` in `renderDropdown()` via `items()->render()`, which runs `Normalizer::dropdown()` a second time over items the parent had already normalized, so nested labels were double-encoded too.

`Normalizer::dropdown()` stays recursive and is the single place items are normalized. `renderDropdown()` no longer re-normalizes: it renders the already-normalized items directly through a private `renderToContainer()` instead of `items()->render()`, so items are normalized exactly once at any nesting depth.

This is the deeper fix for the problem raised in #119, split off into its own PR per review.