### PR TITLE
Fix `Menu` dropdown items being normalized twice + Fix `Dropdown` not wrapping a nested submenu toggle in `<li>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
 - Bug #159: Fix double-encoding of toggle and nested item labels in `Dropdown` (@WarLikeLaux)
 - Bug #168: Fix `Menu` dropdown items being normalized twice, which double-encoded labels, ignored
   `encode => false`, and escaped rendered icon markup (@vjik)
+- Bug #168: Fix `Dropdown` not wrapping a nested submenu toggle in `<li>`, producing invalid markup when a
+  dropdown item with `items` is itself nested inside another dropdown's `items` (@vjik)
 
 ## 2.1.1 September 23, 2025
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
 - Enh #157: Improve psalm type annotations (@Tigrov)
 - New #135: Add `maxItems()` truncation with ellipsis to `Breadcrumbs` widget (@WarLikeLaux)
 - Bug #159: Fix double-encoding of toggle and nested item labels in `Dropdown` (@WarLikeLaux)
+- Bug #168: Fix `Menu` dropdown items being normalized twice, which double-encoded labels, ignored
+  `encode => false`, and escaped rendered icon markup (@vjik)
 
 ## 2.1.1 September 23, 2025
 

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -43,6 +43,12 @@ final class Dropdown extends Widget
     private array $itemContainerAttributes = [];
     private string $itemContainerTag = 'li';
     private array $items = [];
+    /**
+     * Whether this instance renders a nested submenu (always inside an actual `<ul>`, via {@see renderDropdown()}),
+     * as opposed to the top-level {@see items()}, which are rendered directly into {@see $containerTag} and may
+     * not be a list at all.
+     */
+    private bool $isNested = false;
     private array $itemsContainerAttributes = [];
     private string $itemsContainerTag = 'ul';
     private array $splitButtonAttributes = [];
@@ -509,7 +515,7 @@ final class Dropdown extends Widget
      */
     private function renderDropdown(array $items): string
     {
-        return self::widget()
+        $dropdown = self::widget()
             ->container(false)
             ->dividerAttributes($this->dividerAttributes)
             ->headerClass($this->headerClass)
@@ -520,8 +526,10 @@ final class Dropdown extends Widget
             ->itemsContainerAttributes($this->itemsContainerAttributes)
             ->itemTag($this->itemTag)
             ->toggleAttributes($this->toggleAttributes)
-            ->toggleType($this->toggleType)
-            ->renderToContainer($items);
+            ->toggleType($this->toggleType);
+        $dropdown->isNested = true;
+
+        return $dropdown->renderToContainer($items);
     }
 
     private function renderHeader(string $label, array $headerAttributes = []): string
@@ -616,12 +624,16 @@ final class Dropdown extends Widget
             $toggleSplitButton = $this->renderToggleSplitButton($item['label']);
 
             if ($this->toggleType === 'split' && !str_contains($this->containerClass, 'dropstart')) {
-                $lines[] = $toggleSplitButton . PHP_EOL . $toggle . PHP_EOL . $itemContainer;
+                $content = $toggleSplitButton . PHP_EOL . $toggle . PHP_EOL . $itemContainer;
             } elseif ($this->toggleType === 'split' && str_contains($this->containerClass, 'dropstart')) {
-                $lines[] = $toggle . PHP_EOL . $itemContainer . PHP_EOL . $toggleSplitButton;
+                $content = $toggle . PHP_EOL . $itemContainer . PHP_EOL . $toggleSplitButton;
             } else {
-                $lines[] = $toggle . PHP_EOL . $itemContainer;
+                $content = $toggle . PHP_EOL . $itemContainer;
             }
+
+            $lines[] = $this->isNested
+                ? $this->renderItemContainer($content, $item['itemContainerAttributes'])
+                : $content;
         }
 
         /** @psalm-var string[] $lines */

--- a/src/Helper/Normalizer.php
+++ b/src/Helper/Normalizer.php
@@ -80,9 +80,12 @@ final class Normalizer
         foreach ($items as $i => $child) {
             if (is_array($child)) {
                 if (isset($child['items']) && is_array($child['items'])) {
-                    // Left as-is: `Menu::renderDropdown()` hands the whole subtree to `Dropdown::render()`, which
-                    // normalizes it (and all nested levels) itself. Normalizing it here too would double-encode
-                    // labels, ignore `encode => false`, and escape rendered icon markup.
+                    $items[$i] = self::injectMenuContext(
+                        $child,
+                        $currentPath,
+                        $activateItems,
+                        $iconContainerAttributes,
+                    );
                     continue;
                 }
 
@@ -149,6 +152,38 @@ final class Normalizer
         }
 
         return is_bool($item['active']) ? $item['active'] : false;
+    }
+
+    /**
+     * Carries `Menu`-level context into an unnormalized submenu subtree, so `Dropdown::render()` — which does not
+     * know about `currentPath`/`activateItems` or a default `iconContainerAttributes` — still honors them for
+     * nested items that don't override these keys themselves.
+     */
+    private static function injectMenuContext(
+        array $item,
+        string $currentPath,
+        bool $activateItems,
+        array $iconContainerAttributes,
+    ): array {
+        $item['active'] = self::active($item, self::link($item), $currentPath, $activateItems);
+        $item['iconContainerAttributes'] = self::iconContainerAttributes($item, $iconContainerAttributes);
+
+        if (isset($item['items']) && is_array($item['items'])) {
+            $nestedItems = $item['items'];
+            foreach ($nestedItems as $i => $child) {
+                if (is_array($child)) {
+                    $nestedItems[$i] = self::injectMenuContext(
+                        $child,
+                        $currentPath,
+                        $activateItems,
+                        $iconContainerAttributes,
+                    );
+                }
+            }
+            $item['items'] = $nestedItems;
+        }
+
+        return $item;
     }
 
     private static function disabled(array $item): bool

--- a/src/Helper/Normalizer.php
+++ b/src/Helper/Normalizer.php
@@ -80,8 +80,8 @@ final class Normalizer
         foreach ($items as $i => $child) {
             if (is_array($child)) {
                 if (isset($child['items']) && is_array($child['items'])) {
-                    $items[$i] = self::injectMenuContext(
-                        $child,
+                    $items[$i]['items'] = self::injectMenuContext(
+                        $child['items'],
                         $currentPath,
                         $activateItems,
                         $iconContainerAttributes,
@@ -156,34 +156,38 @@ final class Normalizer
 
     /**
      * Carries `Menu`-level context into an unnormalized submenu subtree, so `Dropdown::render()` — which does not
-     * know about `currentPath`/`activateItems` or a default `iconContainerAttributes` — still honors them for
-     * nested items that don't override these keys themselves.
+     * know about `currentPath`/`activateItems` or a default `iconContainerAttributes` — still honors them for leaf
+     * items that don't override these keys themselves. Submenu (toggle) nodes are left untouched and only
+     * recursed into, matching how `Dropdown` normalizes their own `active`/`label` independently.
+     *
+     * The leaf's `link` is also pre-resolved (defaulting to `''`, not `Dropdown`'s own `'/'` default) so a
+     * linkless leaf still renders as a header instead of `Dropdown` turning it into a clickable `/` link.
      */
     private static function injectMenuContext(
-        array $item,
+        array $items,
         string $currentPath,
         bool $activateItems,
         array $iconContainerAttributes,
     ): array {
-        $item['active'] = self::active($item, self::link($item), $currentPath, $activateItems);
-        $item['iconContainerAttributes'] = self::iconContainerAttributes($item, $iconContainerAttributes);
-
-        if (isset($item['items']) && is_array($item['items'])) {
-            $nestedItems = $item['items'];
-            foreach ($nestedItems as $i => $child) {
-                if (is_array($child)) {
-                    $nestedItems[$i] = self::injectMenuContext(
-                        $child,
+        foreach ($items as $i => &$child) {
+            if (is_array($child)) {
+                if (isset($child['items']) && is_array($child['items'])) {
+                    $child['items'] = self::injectMenuContext(
+                        $child['items'],
                         $currentPath,
                         $activateItems,
                         $iconContainerAttributes,
                     );
+                    continue;
                 }
+
+                $child['link'] = self::link($child);
+                $child['active'] = self::active($child, $child['link'], $currentPath, $activateItems);
+                $child['iconContainerAttributes'] = self::iconContainerAttributes($child, $iconContainerAttributes);
             }
-            $item['items'] = $nestedItems;
         }
 
-        return $item;
+        return $items;
     }
 
     private static function disabled(array $item): bool

--- a/src/Helper/Normalizer.php
+++ b/src/Helper/Normalizer.php
@@ -80,39 +80,37 @@ final class Normalizer
         foreach ($items as $i => $child) {
             if (is_array($child)) {
                 if (isset($child['items']) && is_array($child['items'])) {
-                    $items[$i]['items'] = self::menu(
-                        $child['items'],
-                        $currentPath,
-                        $activateItems,
-                        $iconContainerAttributes,
-                    );
-                } else {
-                    $items[$i]['link'] = self::link($child);
-                    $items[$i]['linkAttributes'] = self::linkAttributes($child);
-                    $items[$i]['active'] = self::active(
-                        $child,
-                        $items[$i]['link'],
-                        $currentPath,
-                        $activateItems,
-                    );
-                    $items[$i]['disabled'] = self::disabled($child);
-                    $items[$i]['visible'] = self::visible($child);
-                    $items[$i]['label'] = self::renderLabel(
-                        self::label($child),
-                        self::icon($child),
-                        self::iconAttributes($child),
-                        self::iconClass($child),
-                        self::iconContainerAttributes($child, $iconContainerAttributes),
-                    );
-
-                    unset(
-                        $items[$i]['encode'],
-                        $items[$i]['icon'],
-                        $items[$i]['iconAttributes'],
-                        $items[$i]['iconClass'],
-                        $items[$i]['iconContainerAttributes'],
-                    );
+                    // Left as-is: `Menu::renderDropdown()` hands the whole subtree to `Dropdown::render()`, which
+                    // normalizes it (and all nested levels) itself. Normalizing it here too would double-encode
+                    // labels, ignore `encode => false`, and escape rendered icon markup.
+                    continue;
                 }
+
+                $items[$i]['link'] = self::link($child);
+                $items[$i]['linkAttributes'] = self::linkAttributes($child);
+                $items[$i]['active'] = self::active(
+                    $child,
+                    $items[$i]['link'],
+                    $currentPath,
+                    $activateItems,
+                );
+                $items[$i]['disabled'] = self::disabled($child);
+                $items[$i]['visible'] = self::visible($child);
+                $items[$i]['label'] = self::renderLabel(
+                    self::label($child),
+                    self::icon($child),
+                    self::iconAttributes($child),
+                    self::iconClass($child),
+                    self::iconContainerAttributes($child, $iconContainerAttributes),
+                );
+
+                unset(
+                    $items[$i]['encode'],
+                    $items[$i]['icon'],
+                    $items[$i]['iconAttributes'],
+                    $items[$i]['iconClass'],
+                    $items[$i]['iconContainerAttributes'],
+                );
             }
         }
 

--- a/tests/Dropdown/DropdownTest.php
+++ b/tests/Dropdown/DropdownTest.php
@@ -447,6 +447,40 @@ final class DropdownTest extends TestCase
         );
     }
 
+    public function testNestedSubDropdownIsWrappedInListItem(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <div>
+            <button id="dropdown-1" type="button">Outer</button>
+            <ul aria-labelledby="dropdown-1">
+            <li><button id="dropdown-2" type="button">Sub Dropdown</button>
+            <ul aria-labelledby="dropdown-2">
+            <li><a href="/deep">Deep</a></li>
+            </ul></li>
+            </ul>
+            </div>
+            HTML,
+            Dropdown::widget()
+                ->items([
+                    [
+                        'label' => 'Outer',
+                        'link' => '#',
+                        'items' => [
+                            [
+                                'label' => 'Sub Dropdown',
+                                'link' => '#',
+                                'items' => [
+                                    ['label' => 'Deep', 'link' => '/deep'],
+                                ],
+                            ],
+                        ],
+                    ],
+                ])
+                ->render(),
+        );
+    }
+
     public function testToggleLinkIconIsNotDoubleEncoded(): void
     {
         Assert::equalsWithoutLE(

--- a/tests/Menu/MenuTest.php
+++ b/tests/Menu/MenuTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Yiisoft\Yii\Widgets\Tests\Menu;
 
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 use Stringable;
 use Yiisoft\Html\IdGenerator;
@@ -380,6 +381,42 @@ final class MenuTest extends TestCase
                         ],
                         ['label' => 'Link', 'link' => '#'],
                         ['label' => 'Disabled', 'link' => '#', 'disabled' => true],
+                    ],
+                )
+                ->render(),
+        );
+    }
+
+    #[TestWith(['Black & White', [], 'Black &amp; White'])]
+    #[TestWith(['<b>Bold</b>', ['encode' => false], '<b>Bold</b>'])]
+    #[TestWith([
+        'Home',
+        ['icon' => '🏠', 'iconContainerAttributes' => ['class' => 'me-2']],
+        '<span class="me-2"><i>🏠</i></span>Home',
+    ])]
+    public function testDropdownItemsAreNormalizedOnce(string $label, array $itemOptions, string $expectedLabel): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <ul>
+            <li>
+            <a aria-expanded="false" data-bs-toggle="dropdown" role="button" id="dropdown-1" href="#">Dropdown</a>
+            <ul aria-labelledby="dropdown-1">
+            <li><a href="#">{$expectedLabel}</a></li>
+            </ul>
+            </li>
+            </ul>
+            HTML,
+            Menu::widget()
+                ->items(
+                    [
+                        [
+                            'label' => 'Dropdown',
+                            'link' => '#',
+                            'items' => [
+                                ['label' => $label, 'link' => '#', ...$itemOptions],
+                            ],
+                        ],
                     ],
                 )
                 ->render(),

--- a/tests/Menu/MenuTest.php
+++ b/tests/Menu/MenuTest.php
@@ -483,6 +483,37 @@ final class MenuTest extends TestCase
         );
     }
 
+    public function testDropdownLeafItemWithoutLinkRendersAsHeaderAndIsNotActive(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <ul>
+            <li>
+            <a aria-expanded="false" data-bs-toggle="dropdown" role="button" id="dropdown-1" href="#">Dropdown</a>
+            <ul aria-labelledby="dropdown-1">
+            <li><span>Section header</span></li>
+            <li><a href="/x">Real link</a></li>
+            </ul>
+            </li>
+            </ul>
+            HTML,
+            Menu::widget()
+                ->items(
+                    [
+                        [
+                            'label' => 'Dropdown',
+                            'link' => '#',
+                            'items' => [
+                                ['label' => 'Section header'],
+                                ['label' => 'Real link', 'link' => '/x'],
+                            ],
+                        ],
+                    ],
+                )
+                ->render(),
+        );
+    }
+
     public function testFirstItemCssClass(): void
     {
         Assert::equalsWithoutLE(

--- a/tests/Menu/MenuTest.php
+++ b/tests/Menu/MenuTest.php
@@ -514,6 +514,48 @@ final class MenuTest extends TestCase
         );
     }
 
+    public function testDropdownItemsInheritMenuContextThroughNestedSubmenus(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <ul>
+            <li>
+            <a aria-expanded="false" data-bs-toggle="dropdown" role="button" id="dropdown-1" href="#">Dropdown</a>
+            <ul aria-labelledby="dropdown-1">
+            <li>
+            <a aria-expanded="false" data-bs-toggle="dropdown" role="button" id="dropdown-2" href="#">Sub Dropdown</a>
+            <ul aria-labelledby="dropdown-2">
+            <li><a aria-current="page" class="active" href="/deep"><span class="me-2"><i>🏠</i></span>Deep</a></li>
+            </ul>
+            </li>
+            </ul>
+            </li>
+            </ul>
+            HTML,
+            Menu::widget()
+                ->currentPath('/deep')
+                ->iconContainerAttributes(['class' => 'me-2'])
+                ->items(
+                    [
+                        [
+                            'label' => 'Dropdown',
+                            'link' => '#',
+                            'items' => [
+                                [
+                                    'label' => 'Sub Dropdown',
+                                    'link' => '#',
+                                    'items' => [
+                                        ['label' => 'Deep', 'link' => '/deep', 'icon' => '🏠'],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                )
+                ->render(),
+        );
+    }
+
     public function testFirstItemCssClass(): void
     {
         Assert::equalsWithoutLE(

--- a/tests/Menu/MenuTest.php
+++ b/tests/Menu/MenuTest.php
@@ -423,6 +423,66 @@ final class MenuTest extends TestCase
         );
     }
 
+    public function testDropdownItemsInheritIconContainerAttributesFromMenu(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <ul>
+            <li>
+            <a aria-expanded="false" data-bs-toggle="dropdown" role="button" id="dropdown-1" href="#">Dropdown</a>
+            <ul aria-labelledby="dropdown-1">
+            <li><a href="#"><span class="me-2"><i>🏠</i></span>Home</a></li>
+            </ul>
+            </li>
+            </ul>
+            HTML,
+            Menu::widget()
+                ->iconContainerAttributes(['class' => 'me-2'])
+                ->items(
+                    [
+                        [
+                            'label' => 'Dropdown',
+                            'link' => '#',
+                            'items' => [
+                                ['label' => 'Home', 'link' => '#', 'icon' => '🏠'],
+                            ],
+                        ],
+                    ],
+                )
+                ->render(),
+        );
+    }
+
+    public function testDropdownItemsInheritCurrentPathAndActivateItemsFromMenu(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <ul>
+            <li>
+            <a aria-expanded="false" data-bs-toggle="dropdown" role="button" id="dropdown-1" href="#">Dropdown</a>
+            <ul aria-labelledby="dropdown-1">
+            <li><a aria-current="page" class="active" href="/sub">Sub</a></li>
+            </ul>
+            </li>
+            </ul>
+            HTML,
+            Menu::widget()
+                ->currentPath('/sub')
+                ->items(
+                    [
+                        [
+                            'label' => 'Dropdown',
+                            'link' => '#',
+                            'items' => [
+                                ['label' => 'Sub', 'link' => '/sub'],
+                            ],
+                        ],
+                    ],
+                )
+                ->render(),
+        );
+    }
+
     public function testFirstItemCssClass(): void
     {
         Assert::equalsWithoutLE(

--- a/tests/Menu/MenuTest.php
+++ b/tests/Menu/MenuTest.php
@@ -522,12 +522,10 @@ final class MenuTest extends TestCase
             <li>
             <a aria-expanded="false" data-bs-toggle="dropdown" role="button" id="dropdown-1" href="#">Dropdown</a>
             <ul aria-labelledby="dropdown-1">
-            <li>
-            <a aria-expanded="false" data-bs-toggle="dropdown" role="button" id="dropdown-2" href="#">Sub Dropdown</a>
+            <li><a aria-expanded="false" data-bs-toggle="dropdown" role="button" id="dropdown-2" href="#">Sub Dropdown</a>
             <ul aria-labelledby="dropdown-2">
             <li><a aria-current="page" class="active" href="/deep"><span class="me-2"><i>🏠</i></span>Deep</a></li>
-            </ul>
-            </li>
+            </ul></li>
             </ul>
             </li>
             </ul>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌